### PR TITLE
[OpenAPI] Add endpoint for update event details

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -72,10 +72,10 @@ rules:
         function: truthy
         message: Response 500 is required
 
-  # 401을 제외한 모든 응답 코드는 content를 포함해야함
+  # 400, 401, 404를 제외한 모든 응답 코드는 content를 포함해야함
   operation-responsedetail-content-convention:
-    description: All Operation response might include content, except 401
-    given: $.paths[*][*].responses[?(@property != '401')]
+    description: All Operation response might include content, except 400, 401 and 404
+    given: $.paths[*][*].responses[?(@property != '400' && @property != '401' && @property != '404')]
     severity: error
     then:
       - field: 'content'

--- a/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEventEndpoints.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEventEndpoints.cs
@@ -88,7 +88,7 @@ public static class AdminEventEndpoints
             return Results.Ok();
         })
         .Accepts<AdminEventDetails>(contentType: "application/json")
-        .Produces(statusCode: StatusCodes.Status204NoContent)
+        .Produces<AdminEventDetails>(statusCode: StatusCodes.Status200OK, contentType: "application/json")
         .Produces(statusCode: StatusCodes.Status401Unauthorized)
         .Produces<string>(statusCode: StatusCodes.Status500InternalServerError, contentType: "text/plain")
         .WithTags("admin")

--- a/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEventEndpoints.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEventEndpoints.cs
@@ -82,8 +82,8 @@ public static class AdminEventEndpoints
         // Todo: Issue #19 https://github.com/aliencube/azure-openai-sdk-proxy/issues/19
         // Need authorization by admin
         var builder = app.MapPut(AdminEndpointUrls.AdminEventDetails, (
-            [FromBody] AdminEventDetails payload,
-            [FromRoute] string eventId) =>
+            [FromRoute] string eventId,
+            [FromBody] AdminEventDetails payload) =>
         {
             // Todo: Issue #203 https://github.com/aliencube/azure-openai-sdk-proxy/issues/203
             return Results.Ok();
@@ -91,7 +91,7 @@ public static class AdminEventEndpoints
         .Accepts<AdminEventDetails>(contentType: "application/json")
         .Produces<AdminEventDetails>(statusCode: StatusCodes.Status200OK, contentType: "application/json")
         .Produces(statusCode: StatusCodes.Status401Unauthorized)
-        .Produces<string>(statusCode: StatusCodes.Status404NotFound, contentType: "text/plain")
+        .Produces(statusCode: StatusCodes.Status404NotFound, contentType: "text/plain")
         .Produces<string>(statusCode: StatusCodes.Status500InternalServerError, contentType: "text/plain")
         .WithTags("admin")
         .WithName("UpdateAdminEventDetails")

--- a/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEventEndpoints.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEventEndpoints.cs
@@ -91,7 +91,7 @@ public static class AdminEventEndpoints
         .Accepts<AdminEventDetails>(contentType: "application/json")
         .Produces<AdminEventDetails>(statusCode: StatusCodes.Status200OK, contentType: "application/json")
         .Produces(statusCode: StatusCodes.Status401Unauthorized)
-        .Produces(statusCode: StatusCodes.Status404NotFound, contentType: "text/plain")
+        .Produces(statusCode: StatusCodes.Status404NotFound)
         .Produces<string>(statusCode: StatusCodes.Status500InternalServerError, contentType: "text/plain")
         .WithTags("admin")
         .WithName("UpdateAdminEventDetails")

--- a/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEventEndpoints.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEventEndpoints.cs
@@ -82,6 +82,7 @@ public static class AdminEventEndpoints
         // Todo: Issue #19 https://github.com/aliencube/azure-openai-sdk-proxy/issues/19
         // Need authorization by admin
         var builder = app.MapPut(AdminEndpointUrls.AdminEventDetails, (
+            [FromBody] AdminEventDetails payload,
             [FromRoute] string eventId) =>
         {
             // Todo: Issue #203 https://github.com/aliencube/azure-openai-sdk-proxy/issues/203
@@ -90,6 +91,7 @@ public static class AdminEventEndpoints
         .Accepts<AdminEventDetails>(contentType: "application/json")
         .Produces<AdminEventDetails>(statusCode: StatusCodes.Status200OK, contentType: "application/json")
         .Produces(statusCode: StatusCodes.Status401Unauthorized)
+        .Produces(statusCode: StatusCodes.Status404NotFound)
         .Produces<string>(statusCode: StatusCodes.Status500InternalServerError, contentType: "text/plain")
         .WithTags("admin")
         .WithName("UpdateAdminEventDetails")

--- a/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEventEndpoints.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEventEndpoints.cs
@@ -56,15 +56,16 @@ public static class AdminEventEndpoints
             // Todo: Issue #203 https://github.com/aliencube/azure-openai-sdk-proxy/issues/203
             return Results.Ok();
         })
-        .Produces(statusCode: StatusCodes.Status200OK)
+        .Accepts<AdminEventDetails>(contentType: "application/json")
+        .Produces(statusCode: StatusCodes.Status204NoContent)
         .Produces(statusCode: StatusCodes.Status401Unauthorized)
         .Produces<string>(statusCode: StatusCodes.Status500InternalServerError, contentType: "text/plain")
         .WithTags("admin")
         .WithName("UpdateAdminEventDetails")
         .WithOpenApi(operation =>
         {
-            operation.Summary = "Updates event details by the given event ID";
-            operation.Description = "This endpoint updates event details by event id, api for admin users";
+            operation.Summary = "Updates event details from the given event ID";
+            operation.Description = "This endpoint updates the event details from the given event ID.";
 
             return operation;
         });

--- a/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEventEndpoints.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEventEndpoints.cs
@@ -91,7 +91,7 @@ public static class AdminEventEndpoints
         .Accepts<AdminEventDetails>(contentType: "application/json")
         .Produces<AdminEventDetails>(statusCode: StatusCodes.Status200OK, contentType: "application/json")
         .Produces(statusCode: StatusCodes.Status401Unauthorized)
-        .Produces(statusCode: StatusCodes.Status404NotFound)
+        .Produces<string>(statusCode: StatusCodes.Status404NotFound, contentType: "text/plain")
         .Produces<string>(statusCode: StatusCodes.Status500InternalServerError, contentType: "text/plain")
         .WithTags("admin")
         .WithName("UpdateAdminEventDetails")

--- a/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEventEndpoints.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEventEndpoints.cs
@@ -40,4 +40,35 @@ public static class AdminEventEndpoints
 
         return builder;
     }
+
+    /// <summary>
+    /// Adds the update event details by admin endpoint
+    /// </summary>
+    /// <param name="app"><see cref="WebApplication"/> instance.</param>
+    /// <returns>Returns <see cref="RouteHandlerBuilder"/> instance.</returns>
+    public static RouteHandlerBuilder AddUpdateAdminEvents(this WebApplication app)
+    {
+        // Todo: Issue #19 https://github.com/aliencube/azure-openai-sdk-proxy/issues/19
+        // Need authorization by admin
+        var builder = app.MapPut(AdminEndpointUrls.AdminEventDetails, (
+            [FromRoute] string eventId) =>
+        {
+            // Todo: Issue #203 https://github.com/aliencube/azure-openai-sdk-proxy/issues/203
+            return Results.Ok();
+        })
+        .Produces(statusCode: StatusCodes.Status200OK)
+        .Produces(statusCode: StatusCodes.Status401Unauthorized)
+        .Produces<string>(statusCode: StatusCodes.Status500InternalServerError, contentType: "text/plain")
+        .WithTags("admin")
+        .WithName("UpdateAdminEventDetails")
+        .WithOpenApi(operation =>
+        {
+            operation.Summary = "Updates event details by the given event ID";
+            operation.Description = "This endpoint updates event details by event id, api for admin users";
+
+            return operation;
+        });
+
+        return builder;
+    }
 }

--- a/src/AzureOpenAIProxy.ApiApp/Program.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Program.cs
@@ -41,5 +41,6 @@ app.AddChatCompletions();
 
 // Admin Endpoints
 app.AddAdminEvents();
+app.AddUpdateAdminEvents();
 
 await app.RunAsync();

--- a/test/AzureOpenAIProxy.AppHost.Tests/ApiApp/Endpoints/AdminUpdateEventDetailsOpenApiTests.cs
+++ b/test/AzureOpenAIProxy.AppHost.Tests/ApiApp/Endpoints/AdminUpdateEventDetailsOpenApiTests.cs
@@ -1,0 +1,166 @@
+﻿using System.Text.Json;
+
+using FluentAssertions;
+
+using AzureOpenAIProxy.AppHost.Tests.Fixtures;
+
+namespace AzureOpenAIProxy.AppHost.Tests.ApiApp.Endpoints;
+
+public class AdminUpdateEventDetailsOpenApiTests(AspireAppHostFixture host) : IClassFixture<AspireAppHostFixture>
+{
+    [Fact]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Path()
+    {
+        // Arrange
+        using var httpClient = host.App!.CreateHttpClient("apiapp");
+
+        // Act
+        var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
+        var openapi = JsonSerializer.Deserialize<JsonDocument>(json);
+
+        // Assert
+        var result = openapi!.RootElement.GetProperty("paths")
+                                         .TryGetProperty("/admin/events/{eventId}", out var property) ? property : default;
+        result.ValueKind.Should().Be(JsonValueKind.Object);
+    }
+
+    [Fact]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Verb()
+    {
+        // Arrange
+        using var httpClient = host.App!.CreateHttpClient("apiapp");
+
+        // Act
+        var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
+        var openapi = JsonSerializer.Deserialize<JsonDocument>(json);
+
+        // Assert
+        var result = openapi!.RootElement.GetProperty("paths")
+                                         .GetProperty("/admin/events/{eventId}")
+                                         .TryGetProperty("put", out var property) ? property : default;
+        result.ValueKind.Should().Be(JsonValueKind.Object);
+    }
+
+    [Theory]
+    [InlineData("admin")]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Tags(string tag)
+    {
+        // Arrange
+        using var httpClient = host.App!.CreateHttpClient("apiapp");
+
+        // Act
+        var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
+        var openapi = JsonSerializer.Deserialize<JsonDocument>(json);
+
+        // Assert
+        var result = openapi!.RootElement.GetProperty("paths")
+                                         .GetProperty("/admin/events/{eventId}")
+                                         .GetProperty("put")
+                                         .TryGetProperty("tags", out var property) ? property : default;
+        result.ValueKind.Should().Be(JsonValueKind.Array);
+        result.EnumerateArray().Select(p => p.GetString()).Should().Contain(tag);
+    }
+
+    [Theory]
+    [InlineData("summary")]
+    [InlineData("description")]
+    [InlineData("operationId")]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Value(string attribute)
+    {
+        // Arrange
+        using var httpClient = host.App!.CreateHttpClient("apiapp");
+
+        // Act
+        var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
+        var openapi = JsonSerializer.Deserialize<JsonDocument>(json);
+
+        // Assert
+        var result = openapi!.RootElement.GetProperty("paths")
+                                         .GetProperty("/admin/events/{eventId}")
+                                         .GetProperty("put")
+                                         .TryGetProperty(attribute, out var property) ? property : default;
+        result.ValueKind.Should().Be(JsonValueKind.String);
+    }
+
+    [Theory]
+    [InlineData("parameters")]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Array(string attribute)
+    {
+        // Arrange
+        using var httpClient = host.App!.CreateHttpClient("apiapp");
+
+        // Act
+        var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
+        var openapi = JsonSerializer.Deserialize<JsonDocument>(json);
+
+        // Assert
+        var result = openapi!.RootElement.GetProperty("paths")
+                                         .GetProperty("/admin/events/{eventId}")
+                                         .GetProperty("put")
+                                         .TryGetProperty(attribute, out var property) ? property : default;
+        result.ValueKind.Should().Be(JsonValueKind.Array);
+    }
+
+    [Theory]
+    [InlineData("eventId")]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Path_Parameter(string name)
+    {
+        // Arrange
+        using var httpClient = host.App!.CreateHttpClient("apiapp");
+
+        // Act
+        var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
+        var openapi = JsonSerializer.Deserialize<JsonDocument>(json);
+
+        // Assert
+        var result = openapi!.RootElement.GetProperty("paths")
+                                         .GetProperty("/admin/events/{eventId}")
+                                         .GetProperty("put")
+                                         .GetProperty("parameters")
+                                         .EnumerateArray()
+                                         .Where(p => p.GetProperty("in").GetString() == "path")
+                                         .Select(p => p.GetProperty("name").ToString());
+        result.Should().Contain(name);
+    }
+
+    [Theory]
+    [InlineData("responses")]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Object(string attribute)
+    {
+        // Arrange
+        using var httpClient = host.App!.CreateHttpClient("apiapp");
+
+        // Act
+        var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
+        var openapi = JsonSerializer.Deserialize<JsonDocument>(json);
+
+        // Assert
+        var result = openapi!.RootElement.GetProperty("paths")
+                                         .GetProperty("/admin/events/{eventId}")
+                                         .GetProperty("put")
+                                         .TryGetProperty(attribute, out var property) ? property : default;
+        result.ValueKind.Should().Be(JsonValueKind.Object);
+    }
+
+    [Theory]
+    [InlineData("200")]
+    [InlineData("401")]
+    [InlineData("500")]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Response(string attribute)
+    {
+        // Arrange
+        using var httpClient = host.App!.CreateHttpClient("apiapp");
+
+        // Act
+        var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
+        var openapi = JsonSerializer.Deserialize<JsonDocument>(json);
+
+        // Assert
+        var result = openapi!.RootElement.GetProperty("paths")
+                                         .GetProperty("/admin/events/{eventId}")
+                                         .GetProperty("put")
+                                         .GetProperty("responses")
+                                         .TryGetProperty(attribute, out var property) ? property : default;
+        result.ValueKind.Should().Be(JsonValueKind.Object);
+    }
+}

--- a/test/AzureOpenAIProxy.AppHost.Tests/ApiApp/Endpoints/AdminUpdateEventDetailsOpenApiTests.cs
+++ b/test/AzureOpenAIProxy.AppHost.Tests/ApiApp/Endpoints/AdminUpdateEventDetailsOpenApiTests.cs
@@ -145,7 +145,7 @@ public class AdminUpdateEventDetailsOpenApiTests(AspireAppHostFixture host) : IC
 
 
     [Theory]
-    [InlineData("204")]
+    [InlineData("200")]
     [InlineData("401")]
     [InlineData("500")]
     public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Response(string attribute)

--- a/test/AzureOpenAIProxy.AppHost.Tests/ApiApp/Endpoints/AdminUpdateEventDetailsOpenApiTests.cs
+++ b/test/AzureOpenAIProxy.AppHost.Tests/ApiApp/Endpoints/AdminUpdateEventDetailsOpenApiTests.cs
@@ -147,6 +147,7 @@ public class AdminUpdateEventDetailsOpenApiTests(AspireAppHostFixture host) : IC
     [Theory]
     [InlineData("200")]
     [InlineData("401")]
+    [InlineData("404")]
     [InlineData("500")]
     public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Response(string attribute)
     {

--- a/test/AzureOpenAIProxy.AppHost.Tests/ApiApp/Endpoints/AdminUpdateEventDetailsOpenApiTests.cs
+++ b/test/AzureOpenAIProxy.AppHost.Tests/ApiApp/Endpoints/AdminUpdateEventDetailsOpenApiTests.cs
@@ -124,6 +124,7 @@ public class AdminUpdateEventDetailsOpenApiTests(AspireAppHostFixture host) : IC
     }
 
     [Theory]
+    [InlineData("requestBody")]
     [InlineData("responses")]
     public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Object(string attribute)
     {
@@ -142,8 +143,9 @@ public class AdminUpdateEventDetailsOpenApiTests(AspireAppHostFixture host) : IC
         result.ValueKind.Should().Be(JsonValueKind.Object);
     }
 
+
     [Theory]
-    [InlineData("200")]
+    [InlineData("204")]
     [InlineData("401")]
     [InlineData("500")]
     public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Response(string attribute)
@@ -161,6 +163,39 @@ public class AdminUpdateEventDetailsOpenApiTests(AspireAppHostFixture host) : IC
                                          .GetProperty("put")
                                          .GetProperty("responses")
                                          .TryGetProperty(attribute, out var property) ? property : default;
+        result.ValueKind.Should().Be(JsonValueKind.Object);
+    }
+
+    [Fact]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Schemas()
+    {
+        // Arrange
+        using var httpClient = host.App!.CreateHttpClient("apiapp");
+
+        // Act
+        var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
+        var openapi = JsonSerializer.Deserialize<JsonDocument>(json);
+
+        // Assert
+        var result = openapi!.RootElement.GetProperty("components")
+                                         .TryGetProperty("schemas", out var property) ? property : default;
+        result.ValueKind.Should().Be(JsonValueKind.Object);
+    }
+
+    [Fact]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Model()
+    {
+        // Arrange
+        using var httpClient = host.App!.CreateHttpClient("apiapp");
+
+        // Act
+        var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
+        var openapi = JsonSerializer.Deserialize<JsonDocument>(json);
+
+        // Assert
+        var result = openapi!.RootElement.GetProperty("components")
+                                         .GetProperty("schemas")
+                                         .TryGetProperty("AdminEventDetails", out var property) ? property : default;
         result.ValueKind.Should().Be(JsonValueKind.Object);
     }
 }


### PR DESCRIPTION
https://github.com/aliencube/azure-openai-sdk-proxy/issues/202


- AddAdminEvents 함수 변경점
  - Add -> Map으로 이름 변경
    - DI Container에 추가 시 `Add`, 미들웨어 추가 시 `Use`, 엔드포인트 추가 시 `Map`으로 지정하였습니다.

  - 리턴 타입과 인수를 `IEndpointRouteBuilder`로 변경
    - 해당 변경점 토대로 신규 함수 작성하지 않고 동일 함수에서 신규 엔드포인트 추가하였습니다.

   - 신규 엔드포인트 `UpdateAdminEventDetails` 추가


- 테스트 코드 추가: 신규 엔드포인트 `UpdateAdminEventDetails`

확인 부탁드립니다. 감사합니다.