### PR TITLE
[Playground] Component - Tab for system message and parameters (UI only) #225

### DIFF
--- a/src/AzureOpenAIProxy.PlaygroundApp/Components/Pages/Home.razor
+++ b/src/AzureOpenAIProxy.PlaygroundApp/Components/Pages/Home.razor
@@ -8,5 +8,3 @@
 Welcome to your new app.
 
 <ChatWindowComponent @rendermode="InteractiveServer"/>
-
-<ConfigTabComponent @rendermode="InteractiveServer"/>

--- a/src/AzureOpenAIProxy.PlaygroundApp/Components/Pages/Home.razor
+++ b/src/AzureOpenAIProxy.PlaygroundApp/Components/Pages/Home.razor
@@ -7,4 +7,6 @@
 
 Welcome to your new app.
 
-<ChatWindowComponent @rendermode="InteractiveServer" />
+<ChatWindowComponent @rendermode="InteractiveServer"/>
+
+<ConfigTabComponent @rendermode="InteractiveServer"/>

--- a/src/AzureOpenAIProxy.PlaygroundApp/Components/Pages/Playground.razor
+++ b/src/AzureOpenAIProxy.PlaygroundApp/Components/Pages/Playground.razor
@@ -1,5 +1,8 @@
 @page "/playground"
+@using AzureOpenAIProxy.PlaygroundApp.Components.UI
 
 <PageTitle>Playground Page</PageTitle>
 
 <h1>playground page!</h1>
+
+<ConfigTabComponent @rendermode="InteractiveServer"/>

--- a/src/AzureOpenAIProxy.PlaygroundApp/Components/Pages/Playground.razor
+++ b/src/AzureOpenAIProxy.PlaygroundApp/Components/Pages/Playground.razor
@@ -1,5 +1,4 @@
 @page "/playground"
-@using AzureOpenAIProxy.PlaygroundApp.Components.UI
 
 <PageTitle>Playground Page</PageTitle>
 

--- a/src/AzureOpenAIProxy.PlaygroundApp/Components/UI/ConfigTabComponent.razor
+++ b/src/AzureOpenAIProxy.PlaygroundApp/Components/UI/ConfigTabComponent.razor
@@ -1,15 +1,15 @@
 @using Microsoft.FluentUI.AspNetCore.Components
 
 <FluentTabs ActiveTabId="system-message" OnTabChange="HandleOnTabChange">
-    <FluentTab Label="System message" Id="system-message">
+    <FluentTab Label="System message" Id="system-message-tab">
         This is "System message" tab.
     </FluentTab>
-    <FluentTab Label="Parameters" Id="parameters">
+    <FluentTab Label="Parameters" Id="parameters-tab">
         This is "Parameters" tab.
     </FluentTab>
 </FluentTabs>
 
-<p>[TEST] Active tab changed to: @SelectedTab?.Label</p>
+<p id ="active-tab">[TEST] Active tab changed to: @SelectedTab?.Id</p>
 
 @code {
     FluentTab? SelectedTab;

--- a/src/AzureOpenAIProxy.PlaygroundApp/Components/UI/ConfigTabComponent.razor
+++ b/src/AzureOpenAIProxy.PlaygroundApp/Components/UI/ConfigTabComponent.razor
@@ -1,0 +1,21 @@
+@using Microsoft.FluentUI.AspNetCore.Components
+
+<FluentTabs ActiveTabId="system-message" OnTabChange="HandleOnTabChange">
+    <FluentTab Label="System message" Id="system-message">
+        This is "System message" tab.
+    </FluentTab>
+    <FluentTab Label="Parameters" Id="parameters">
+        This is "Parameters" tab.
+    </FluentTab>
+</FluentTabs>
+
+<p>[TEST] Active tab changed to: @SelectedTab?.Label</p>
+
+@code {
+    FluentTab? SelectedTab;
+
+    private void HandleOnTabChange(FluentTab tab)
+    {
+        SelectedTab = tab;
+    }
+}

--- a/src/AzureOpenAIProxy.PlaygroundApp/Components/UI/ConfigTabComponent.razor
+++ b/src/AzureOpenAIProxy.PlaygroundApp/Components/UI/ConfigTabComponent.razor
@@ -1,4 +1,4 @@
-<FluentTabs Id="config-tab" ActiveTabId="system-message" OnTabChange="HandleOnTabChange">
+<FluentTabs Id="config-tab" ActiveTabId="system-message" OnTabChange="ChangeTab">
     <FluentTab Label="System message" Id="system-message-tab">
         This is "System message" tab.
     </FluentTab>
@@ -7,13 +7,14 @@
     </FluentTab>
 </FluentTabs>
 
-<p id ="active-tab">[TEST] Active tab changed to: @SelectedTab?.Id</p>
+<p id="active-tab">[TEST] Active tab changed to: @SelectedTab?.Id</p>
 
 @code {
     FluentTab? SelectedTab;
 
-    private void HandleOnTabChange(FluentTab tab)
+    private async Task ChangeTab(FluentTab tab)
     {
         SelectedTab = tab;
+        await Task.CompletedTask;
     }
 }

--- a/src/AzureOpenAIProxy.PlaygroundApp/Components/UI/ConfigTabComponent.razor
+++ b/src/AzureOpenAIProxy.PlaygroundApp/Components/UI/ConfigTabComponent.razor
@@ -1,5 +1,3 @@
-@using Microsoft.FluentUI.AspNetCore.Components
-
 <FluentTabs ActiveTabId="system-message" OnTabChange="HandleOnTabChange">
     <FluentTab Label="System message" Id="system-message-tab">
         This is "System message" tab.

--- a/src/AzureOpenAIProxy.PlaygroundApp/Components/UI/ConfigTabComponent.razor
+++ b/src/AzureOpenAIProxy.PlaygroundApp/Components/UI/ConfigTabComponent.razor
@@ -1,4 +1,4 @@
-<FluentTabs ActiveTabId="system-message" OnTabChange="HandleOnTabChange">
+<FluentTabs Id="config-tab" ActiveTabId="system-message" OnTabChange="HandleOnTabChange">
     <FluentTab Label="System message" Id="system-message-tab">
         This is "System message" tab.
     </FluentTab>

--- a/src/AzureOpenAIProxy.PlaygroundApp/Components/_Imports.razor
+++ b/src/AzureOpenAIProxy.PlaygroundApp/Components/_Imports.razor
@@ -14,3 +14,4 @@
 
 @using AzureOpenAIProxy.PlaygroundApp
 @using AzureOpenAIProxy.PlaygroundApp.Components
+@using AzureOpenAIProxy.PlaygroundApp.Components.UI

--- a/src/AzureOpenAIProxy.PlaygroundApp/Components/_Imports.razor
+++ b/src/AzureOpenAIProxy.PlaygroundApp/Components/_Imports.razor
@@ -14,4 +14,3 @@
 
 @using AzureOpenAIProxy.PlaygroundApp
 @using AzureOpenAIProxy.PlaygroundApp.Components
-@using Microsoft.FluentUI.AspNetCore.Components

--- a/src/AzureOpenAIProxy.PlaygroundApp/Components/_Imports.razor
+++ b/src/AzureOpenAIProxy.PlaygroundApp/Components/_Imports.razor
@@ -14,3 +14,4 @@
 
 @using AzureOpenAIProxy.PlaygroundApp
 @using AzureOpenAIProxy.PlaygroundApp.Components
+@using Microsoft.FluentUI.AspNetCore.Components

--- a/src/AzureOpenAIProxy.PlaygroundApp/Program.cs
+++ b/src/AzureOpenAIProxy.PlaygroundApp/Program.cs
@@ -15,8 +15,7 @@ builder.Services.AddRazorComponents()
 builder.Services.AddFluentUIComponents();
 
 builder.Services.AddScoped<IOpenAIApiClient, OpenAIApiClient>();
-
-builder.Services.AddSingleton<Microsoft.FluentUI.AspNetCore.Components.LibraryConfiguration>();
+builder.Services.AddFluentUIComponents();
 
 var app = builder.Build();
 

--- a/src/AzureOpenAIProxy.PlaygroundApp/Program.cs
+++ b/src/AzureOpenAIProxy.PlaygroundApp/Program.cs
@@ -16,6 +16,8 @@ builder.Services.AddFluentUIComponents();
 
 builder.Services.AddScoped<IOpenAIApiClient, OpenAIApiClient>();
 
+builder.Services.AddSingleton<Microsoft.FluentUI.AspNetCore.Components.LibraryConfiguration>();
+
 var app = builder.Build();
 
 app.MapDefaultEndpoints();

--- a/src/AzureOpenAIProxy.PlaygroundApp/Program.cs
+++ b/src/AzureOpenAIProxy.PlaygroundApp/Program.cs
@@ -15,7 +15,6 @@ builder.Services.AddRazorComponents()
 builder.Services.AddFluentUIComponents();
 
 builder.Services.AddScoped<IOpenAIApiClient, OpenAIApiClient>();
-builder.Services.AddFluentUIComponents();
 
 var app = builder.Build();
 

--- a/test/AzureOpenAIProxy.PlaygroundApp.Tests/UI/ConfigTabComponentTest.cs
+++ b/test/AzureOpenAIProxy.PlaygroundApp.Tests/UI/ConfigTabComponentTest.cs
@@ -42,13 +42,13 @@ public class ConfigTabComponentTest : PageTest
     [Test]
     [TestCase(
         "fluent-tab#parameters-tab",
-        "fluent-tab-panel#system-message-tab-panel",
-        "fluent-tab-panel#parameters-tab-panel"
+        "fluent-tab-panel#parameters-tab-panel",
+        "fluent-tab-panel#system-message-tab-panel"
     )]
     [TestCase(
         "fluent-tab#system-message-tab",
-        "fluent-tab-panel#parameters-tab-panel",
-        "fluent-tab-panel#system-message-tab-panel"
+        "fluent-tab-panel#system-message-tab-panel",
+        "fluent-tab-panel#parameters-tab-panel"
     )]
     public async Task Given_ConfigTab_When_Changed_Then_Tab_Should_Be_Updated(
         string selectedTabSelector,
@@ -65,7 +65,7 @@ public class ConfigTabComponentTest : PageTest
         await selectedTab.ClickAsync();
 
         // Assert
-        await Expect(selectedPanel).ToBeHiddenAsync();
-        await Expect(hiddenPanel).ToBeVisibleAsync();
+        await Expect(selectedPanel).ToBeVisibleAsync();
+        await Expect(hiddenPanel).ToBeHiddenAsync();
     }
 }

--- a/test/AzureOpenAIProxy.PlaygroundApp.Tests/UI/ConfigTabComponentTest.cs
+++ b/test/AzureOpenAIProxy.PlaygroundApp.Tests/UI/ConfigTabComponentTest.cs
@@ -8,18 +8,15 @@ namespace AzureOpenAIProxy.PlaygroundApp.Tests.UI;
 [Property("Category", "Integration")]
 public class ConfigTabComponentTest : PageTest
 {
-    public override BrowserNewContextOptions ContextOptions() => new()
-    {
-        IgnoreHTTPSErrors = true,
-    };  
-    
+    public override BrowserNewContextOptions ContextOptions() => new() { IgnoreHTTPSErrors = true, };
+
     [SetUp]
     public async Task SetUp()
     {
         await Page.GotoAsync("https://localhost:5001/playground/");
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
     }
-    
+
     [Test]
     public async Task Given_ConfigTab_When_Endpoint_Invoked_Then_ConfigTab_Should_Be_Displayed()
     {
@@ -29,32 +26,46 @@ public class ConfigTabComponentTest : PageTest
         // Assert
         await Expect(configTab).ToBeVisibleAsync();
     }
-    
+
     [Test]
     public async Task Given_ConfigTab_When_Endpoint_Invoked_Then_Id_Should_Be_System_Message_Tab()
     {
         // Act
         var sysMsgPanel = Page.Locator("fluent-tab-panel#system-message-tab-panel");
         var parameterPanel = Page.Locator("fluent-tab-panel#parameters-tab-panel");
-        
+
         // Assert
         await Expect(sysMsgPanel).ToBeVisibleAsync();
         await Expect(parameterPanel).ToBeHiddenAsync();
     }
 
     [Test]
-    public async Task Given_ConfigTab_When_Changed_Then_Tab_Should_Be_Updated()
+    [TestCase(
+        "fluent-tab#parameters-tab",
+        "fluent-tab-panel#system-message-tab-panel",
+        "fluent-tab-panel#parameters-tab-panel"
+    )]
+    [TestCase(
+        "fluent-tab#system-message-tab",
+        "fluent-tab-panel#parameters-tab-panel",
+        "fluent-tab-panel#system-message-tab-panel"
+    )]
+    public async Task Given_ConfigTab_When_Changed_Then_Tab_Should_Be_Updated(
+        string selectedTabSelector,
+        string selectedPanelSelector,
+        string hiddenPanelSelector
+    )
     {
         // Arrange
-        var parameterTab = Page.Locator("fluent-tab#parameters-tab");
-        var sysMsgPanel = Page.Locator("fluent-tab-panel#system-message-tab-panel");
-        var parameterPanel = Page.Locator("fluent-tab-panel#parameters-tab-panel");
-        
+        var selectedTab = Page.Locator(selectedTabSelector);
+        var selectedPanel = Page.Locator(selectedPanelSelector);
+        var hiddenPanel = Page.Locator(hiddenPanelSelector);
+
         // Act
-        await parameterTab.ClickAsync();
-        
+        await selectedTab.ClickAsync();
+
         // Assert
-        await Expect(sysMsgPanel).ToBeHiddenAsync();
-        await Expect(parameterPanel).ToBeVisibleAsync();
+        await Expect(selectedPanel).ToBeHiddenAsync();
+        await Expect(hiddenPanel).ToBeVisibleAsync();
     }
 }

--- a/test/AzureOpenAIProxy.PlaygroundApp.Tests/UI/ConfigTabComponentTest.cs
+++ b/test/AzureOpenAIProxy.PlaygroundApp.Tests/UI/ConfigTabComponentTest.cs
@@ -1,0 +1,60 @@
+using Microsoft.Playwright;
+using Microsoft.Playwright.NUnit;
+
+namespace AzureOpenAIProxy.PlaygroundApp.Tests.UI;
+
+[Parallelizable(ParallelScope.Self)]
+[TestFixture]
+[Property("Category", "Integration")]
+public class ConfigTabComponentTest : PageTest
+{
+    public override BrowserNewContextOptions ContextOptions() => new()
+    {
+        IgnoreHTTPSErrors = true,
+    };  
+    
+    [SetUp]
+    public async Task SetUp()
+    {
+        await Page.GotoAsync("https://localhost:5001/playground/");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+    }
+    
+    [Test]
+    public async Task Given_ConfigTab_When_Endpoint_Invoked_Then_ConfigTab_Should_Be_Displayed()
+    {
+        // Act
+        var configTab = Page.Locator("fluent-tabs#config-tab");
+
+        // Assert
+        await Expect(configTab).ToBeVisibleAsync();
+    }
+    
+    [Test]
+    public async Task Given_ConfigTab_When_Endpoint_Invoked_Then_Id_Should_Be_System_Message_Tab()
+    {
+        // Act
+        var sysMsgPanel = Page.Locator("fluent-tab-panel#system-message-tab-panel");
+        var parameterPanel = Page.Locator("fluent-tab-panel#parameters-tab-panel");
+        
+        // Assert
+        await Expect(sysMsgPanel).ToBeVisibleAsync();
+        await Expect(parameterPanel).ToBeHiddenAsync();
+    }
+
+    [Test]
+    public async Task Given_ConfigTab_When_Changed_Then_Tab_Should_Be_Updated()
+    {
+        // Arrange
+        var parameterTab = Page.Locator("fluent-tab#parameters-tab");
+        var sysMsgPanel = Page.Locator("fluent-tab-panel#system-message-tab-panel");
+        var parameterPanel = Page.Locator("fluent-tab-panel#parameters-tab-panel");
+        
+        // Act
+        await parameterTab.ClickAsync();
+        
+        // Assert
+        await Expect(sysMsgPanel).ToBeHiddenAsync();
+        await Expect(parameterPanel).ToBeVisibleAsync();
+    }
+}


### PR DESCRIPTION
## Description
- #225 
System Message 와 Parameters를 조정할 수 있는 Tab Component를 추가하였습니다.

## Summary of Changes
- ConfigTabComponent 추가 : 
`FluentUI`의 `FluentTab`을 사용하였으며, 탭 전환을 확인할 수 있도록 OnTabChange 이벤트를 추가해두었습니다.

→ `Home` page에 컴포넌트 추가해서 확인하였습니다!

## Questions
- Tab Component 테스트 작성에서 감을 잡지 못하고 있습니다

클릭한 tab의 id에 따라

```
<p id ="active-tab">[TEST] Active tab changed to: @SelectedTab?.Id</p>
```

이 부분의 텍스트에 해당 tab의 id가 포함되는가? 에 대해 작성하고자 했는데,
너무 하드 코딩의 테스트가 되어버리진 않을까 걱정되고, 근본적으로 이렇게 작성하는 게 맞는지도 의문이 드는 상태입니다!