### PR TITLE
[OpenAPI] Add endpoint for list event details #217

### DIFF
--- a/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEndpointUrls.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEndpointUrls.cs
@@ -11,5 +11,5 @@ public static class AdminEndpointUrls
     /// Declares the admin event list endpoint.
     /// </summary>
     //TODO: [tae0y] endpoint 이름 정하기 /admin/events or /admin/eventlist
-    public const string AdminEventList = "/admin/eventlist";
+    public const string AdminEventList = "/admin/events";
 }

--- a/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEndpointUrls.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEndpointUrls.cs
@@ -10,6 +10,9 @@ public static class AdminEndpointUrls
     /// <summary>
     /// Declares the admin event list endpoint.
     /// </summary>
-    //TODO: [tae0y] endpoint 이름 정하기 /admin/events or /admin/eventlist
-    public const string AdminEventList = "/admin/events";
+    /// <remarks>
+    /// - Get method for listing all events
+    /// - Post method for new event creation
+    /// </remarks>
+    public const string AdminEvents = "/admin/events";
 }

--- a/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEndpointUrls.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEndpointUrls.cs
@@ -6,4 +6,10 @@ public static class AdminEndpointUrls
     /// Declares the admin event details endpoint.
     /// </summary>
     public const string AdminEventDetails = "/admin/events/{eventId}";
+
+    /// <summary>
+    /// Declares the admin event list endpoint.
+    /// </summary>
+    //TODO: [tae0y] endpoint 이름 정하기 /admin/events or /admin/eventlist
+    public const string AdminEventList = "/admin/eventlist";
 }

--- a/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEventEndpoints.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEventEndpoints.cs
@@ -62,11 +62,11 @@ public static class AdminEventEndpoints
         .Produces(statusCode: StatusCodes.Status401Unauthorized)
         .Produces<string>(statusCode: StatusCodes.Status500InternalServerError, contentType: "text/plain")
         .WithTags("admin")
-        .WithName("GetAdminEventList")
+        .WithName("GetAdminEvents")
         .WithOpenApi(operation =>
         {
-            operation.Summary = "Gets all event list";
-            operation.Description = "This endpoint gets all event list";
+            operation.Summary = "Gets all events";
+            operation.Description = "This endpoint gets all events";
 
             return operation;
         });

--- a/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEventEndpoints.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEventEndpoints.cs
@@ -58,7 +58,6 @@ public static class AdminEventEndpoints
         })
         .Produces<List<AdminEventDetails>>(statusCode: StatusCodes.Status200OK, contentType: "application/json")
         .Produces(statusCode: StatusCodes.Status401Unauthorized)
-        .Produces<List<AdminEventDetails>>(statusCode: StatusCodes.Status404NotFound)
         .Produces<string>(statusCode: StatusCodes.Status500InternalServerError, contentType: "text/plain")
         .WithTags("admin")
         .WithName("GetAdminEvents")

--- a/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEventEndpoints.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEventEndpoints.cs
@@ -40,4 +40,37 @@ public static class AdminEventEndpoints
 
         return builder;
     }
+
+    /// <summary>
+    /// Adds the get event lists by admin endpoint
+    /// </summary>
+    /// <param name="app"><see cref="WebApplication"/> instance.</param>
+    /// <returns>Returns <see cref="RouteHandlerBuilder"/> instance.</returns>
+    public static RouteHandlerBuilder AddAdminEventList(this WebApplication app)
+    {
+        // Todo: Issue #19 https://github.com/aliencube/azure-openai-sdk-proxy/issues/19
+        // Need authorization by admin
+        //TODO: [tae0y] 파라미터 없이 이벤트를 전체 조회하는게 맞는가?
+        var builder = app.MapGet(AdminEndpointUrls.AdminEventList, () =>
+        {
+            // Todo: Issue #218 https://github.com/aliencube/azure-openai-sdk-proxy/issues/218
+            return Results.Ok();
+            // Todo: Issue #218
+        })
+        //TODO: [tae0y] 이벤트 목록 조회할때는 불필요한 필드가 많은데 어떻게 처리할까?
+        .Produces<List<AdminEventDetails>>(statusCode: StatusCodes.Status200OK, contentType: "application/json")
+        .Produces(statusCode: StatusCodes.Status401Unauthorized)
+        .Produces<string>(statusCode: StatusCodes.Status500InternalServerError, contentType: "text/plain")
+        .WithTags("admin")
+        .WithName("GetAdminEventList")
+        .WithOpenApi(operation =>
+        {
+            operation.Summary = "Gets all event list";
+            operation.Description = "This endpoint gets all event list";
+
+            return operation;
+        });
+
+        return builder;
+    }
 }

--- a/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEventEndpoints.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEventEndpoints.cs
@@ -50,16 +50,15 @@ public static class AdminEventEndpoints
     {
         // Todo: Issue #19 https://github.com/aliencube/azure-openai-sdk-proxy/issues/19
         // Need authorization by admin
-        //TODO: [tae0y] 파라미터 없이 이벤트를 전체 조회하는게 맞는가?
-        var builder = app.MapGet(AdminEndpointUrls.AdminEventList, () =>
+        var builder = app.MapGet(AdminEndpointUrls.AdminEvents, () =>
         {
             // Todo: Issue #218 https://github.com/aliencube/azure-openai-sdk-proxy/issues/218
             return Results.Ok();
             // Todo: Issue #218
         })
-        //TODO: [tae0y] 이벤트 목록 조회할때는 불필요한 필드가 많은데 어떻게 처리할까?
         .Produces<List<AdminEventDetails>>(statusCode: StatusCodes.Status200OK, contentType: "application/json")
         .Produces(statusCode: StatusCodes.Status401Unauthorized)
+        .Produces<List<AdminEventDetails>>(statusCode: StatusCodes.Status404NotFound)
         .Produces<string>(statusCode: StatusCodes.Status500InternalServerError, contentType: "text/plain")
         .WithTags("admin")
         .WithName("GetAdminEvents")

--- a/src/AzureOpenAIProxy.ApiApp/Filters/OpenApiTagFilter.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Filters/OpenApiTagFilter.cs
@@ -16,6 +16,7 @@ public class OpenApiTagFilter : IDocumentFilter
         [
             new OpenApiTag { Name = "weather", Description = "Weather forecast operations" },
             new OpenApiTag { Name = "openai", Description = "Azure OpenAI operations" },
+            new OpenApiTag { Name = "admin", Description = "Admin for organizing events" }
         ];
     }
 }

--- a/src/AzureOpenAIProxy.ApiApp/Program.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Program.cs
@@ -41,5 +41,6 @@ app.AddChatCompletions();
 
 // Admin Endpoints
 app.AddAdminEvents();
+app.AddAdminEventList();
 
 await app.RunAsync();

--- a/test/AzureOpenAIProxy.AppHost.Tests/ApiApp/Endpoints/AdminGetEventListOpenApiTests.cs
+++ b/test/AzureOpenAIProxy.AppHost.Tests/ApiApp/Endpoints/AdminGetEventListOpenApiTests.cs
@@ -1,0 +1,14 @@
+using System.Text.Json;
+
+using AzureOpenAIProxy.AppHost.Tests.Fixtures;
+
+using FluentAssertions;
+
+using IdentityModel.Client;
+
+namespace AzureOpenAIProxy.AppHost.Tests.ApiApp.Endpoints;
+
+public class AdminGetEventListOpenApiTests(AspireAppHostFixture host) : IClassFixture<AspireAppHostFixture>
+{
+    // TODO: [tae0y] 테스트코드 작성하기
+}

--- a/test/AzureOpenAIProxy.AppHost.Tests/ApiApp/Endpoints/AdminGetEventListOpenApiTests.cs
+++ b/test/AzureOpenAIProxy.AppHost.Tests/ApiApp/Endpoints/AdminGetEventListOpenApiTests.cs
@@ -11,4 +11,118 @@ namespace AzureOpenAIProxy.AppHost.Tests.ApiApp.Endpoints;
 public class AdminGetEventListOpenApiTests(AspireAppHostFixture host) : IClassFixture<AspireAppHostFixture>
 {
     // TODO: [tae0y] 테스트코드 작성하기
+    [Fact]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Path()
+    {
+        // Arrange
+        using var httpClient = host.App!.CreateHttpClient("apiapp");
+
+        // Act
+        var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
+        var openapi = JsonSerializer.Deserialize<JsonDocument>(json);
+
+        // Assert
+        var result = openapi!.RootElement.GetProperty("paths")
+                                         .TryGetProperty("/admin/eventlist", out var property) ? property : default;
+        result.ValueKind.Should().Be(JsonValueKind.Object);
+    }
+
+    [Fact]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Verb()
+    {
+        // Arrange
+        using var httpClient = host.App!.CreateHttpClient("apiapp");
+
+        // Act
+        var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
+        var openapi = JsonSerializer.Deserialize<JsonDocument>(json);
+
+        // Assert
+        var result = openapi!.RootElement.GetProperty("paths")
+                                         .GetProperty("/admin/eventlist")
+                                         .TryGetProperty("get", out var property) ? property : default;
+        result.ValueKind.Should().Be(JsonValueKind.Object);
+    }
+
+    [Theory]
+    [InlineData("admin")]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Tags(string tag)
+    {
+        // Arrange
+        using var httpClient = host.App!.CreateHttpClient("apiapp");
+
+        // Act
+        var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
+        var openapi = JsonSerializer.Deserialize<JsonDocument>(json);
+
+        // Assert
+        var result = openapi!.RootElement.GetProperty("paths")
+                                         .GetProperty("/admin/eventlist")
+                                         .GetProperty("get")
+                                         .TryGetProperty("tags", out var property) ? property : default;
+        result.ValueKind.Should().Be(JsonValueKind.Array);
+        result.EnumerateArray().Select(p => p.GetString()).Should().Contain(tag);
+    }
+
+    [Theory]
+    [InlineData("summary")]
+    [InlineData("description")]
+    [InlineData("operationId")]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Value(string attribute)
+    {
+        // Arrange
+        using var httpClient = host.App!.CreateHttpClient("apiapp");
+
+        // Act
+        var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
+        var openapi = JsonSerializer.Deserialize<JsonDocument>(json);
+
+        // Assert
+        var result = openapi!.RootElement.GetProperty("paths")
+                                         .GetProperty("/admin/eventlist")
+                                         .GetProperty("get")
+                                         .TryGetProperty(attribute, out var property) ? property : default;
+        result.ValueKind.Should().Be(JsonValueKind.String);
+    }
+
+    [Theory]
+    [InlineData("responses")]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Object(string attribute)
+    {
+        // Arrange
+        using var httpClient = host.App!.CreateHttpClient("apiapp");
+
+        // Act
+        var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
+        var openapi = JsonSerializer.Deserialize<JsonDocument>(json);
+
+        // Assert
+        var result = openapi!.RootElement.GetProperty("paths")
+                                         .GetProperty("/admin/eventlist")
+                                         .GetProperty("get")
+                                         .TryGetProperty(attribute, out var property) ? property : default;
+        result.ValueKind.Should().Be(JsonValueKind.Object);
+    }
+
+    [Theory]
+    [InlineData("200")]
+    [InlineData("401")]
+    [InlineData("500")]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Response(string attribute)
+    {
+        // Arrange
+        using var httpClient = host.App!.CreateHttpClient("apiapp");
+
+        // Act
+        var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
+        var openapi = JsonSerializer.Deserialize<JsonDocument>(json);
+
+        // Assert
+        var result = openapi!.RootElement.GetProperty("paths")
+                                         .GetProperty("/admin/eventlist")
+                                         .GetProperty("get")
+                                         .GetProperty("responses")
+                                         .TryGetProperty(attribute, out var property) ? property : default;
+        result.ValueKind.Should().Be(JsonValueKind.Object);
+    }
 }

--- a/test/AzureOpenAIProxy.AppHost.Tests/ApiApp/Endpoints/AdminGetEventsOpenApiTests.cs
+++ b/test/AzureOpenAIProxy.AppHost.Tests/ApiApp/Endpoints/AdminGetEventsOpenApiTests.cs
@@ -8,7 +8,7 @@ using IdentityModel.Client;
 
 namespace AzureOpenAIProxy.AppHost.Tests.ApiApp.Endpoints;
 
-public class AdminGetEventListOpenApiTests(AspireAppHostFixture host) : IClassFixture<AspireAppHostFixture>
+public class AdminGetEventsOpenApiTests(AspireAppHostFixture host) : IClassFixture<AspireAppHostFixture>
 {
     // TODO: [tae0y] 테스트코드 작성하기
     [Fact]
@@ -23,7 +23,7 @@ public class AdminGetEventListOpenApiTests(AspireAppHostFixture host) : IClassFi
 
         // Assert
         var result = openapi!.RootElement.GetProperty("paths")
-                                         .TryGetProperty("/admin/eventlist", out var property) ? property : default;
+                                         .TryGetProperty("/admin/events", out var property) ? property : default;
         result.ValueKind.Should().Be(JsonValueKind.Object);
     }
 
@@ -39,7 +39,7 @@ public class AdminGetEventListOpenApiTests(AspireAppHostFixture host) : IClassFi
 
         // Assert
         var result = openapi!.RootElement.GetProperty("paths")
-                                         .GetProperty("/admin/eventlist")
+                                         .GetProperty("/admin/events")
                                          .TryGetProperty("get", out var property) ? property : default;
         result.ValueKind.Should().Be(JsonValueKind.Object);
     }
@@ -57,7 +57,7 @@ public class AdminGetEventListOpenApiTests(AspireAppHostFixture host) : IClassFi
 
         // Assert
         var result = openapi!.RootElement.GetProperty("paths")
-                                         .GetProperty("/admin/eventlist")
+                                         .GetProperty("/admin/events")
                                          .GetProperty("get")
                                          .TryGetProperty("tags", out var property) ? property : default;
         result.ValueKind.Should().Be(JsonValueKind.Array);
@@ -79,7 +79,7 @@ public class AdminGetEventListOpenApiTests(AspireAppHostFixture host) : IClassFi
 
         // Assert
         var result = openapi!.RootElement.GetProperty("paths")
-                                         .GetProperty("/admin/eventlist")
+                                         .GetProperty("/admin/events")
                                          .GetProperty("get")
                                          .TryGetProperty(attribute, out var property) ? property : default;
         result.ValueKind.Should().Be(JsonValueKind.String);
@@ -98,7 +98,7 @@ public class AdminGetEventListOpenApiTests(AspireAppHostFixture host) : IClassFi
 
         // Assert
         var result = openapi!.RootElement.GetProperty("paths")
-                                         .GetProperty("/admin/eventlist")
+                                         .GetProperty("/admin/events")
                                          .GetProperty("get")
                                          .TryGetProperty(attribute, out var property) ? property : default;
         result.ValueKind.Should().Be(JsonValueKind.Object);
@@ -119,7 +119,7 @@ public class AdminGetEventListOpenApiTests(AspireAppHostFixture host) : IClassFi
 
         // Assert
         var result = openapi!.RootElement.GetProperty("paths")
-                                         .GetProperty("/admin/eventlist")
+                                         .GetProperty("/admin/events")
                                          .GetProperty("get")
                                          .GetProperty("responses")
                                          .TryGetProperty(attribute, out var property) ? property : default;


### PR DESCRIPTION
related to #217
(#179 이슈는 사용자 기준으로 이벤트 목록조회, #217은 관리자 기준임)
  
- admin 글로벌 태그 추가
- endpointurl 추가, 별도 파라미터 없이 모든 이벤트 목록을 조회하는 방식
- 테스트 코드 추가 : `AzureOpenAIProxy.AppHost.Tests.ApiApp.Endpoints` > `AdminGetEventListOpenApiTests`
- [Spectral로 OpenAPI 규칙 검사하기](https://github.com/aliencube/azure-openai-sdk-proxy/wiki/Spectral%EB%A1%9C-OpenAPI-%EA%B7%9C%EC%B9%99-%EA%B2%80%EC%82%AC%ED%95%98%EA%B8%B0)를 참고해서 swagger.json도 린팅하여 확인 했습니다 ~