### PR TITLE
Feature/213 admin event create

### DIFF
--- a/infra/aspire.bicep
+++ b/infra/aspire.bicep
@@ -54,6 +54,31 @@ module keyVault './core/security/keyvault.bicep' = {
   }
 }
 
+// Provision Storage Account
+resource storageAccount 'Microsoft.Storage/storageAccounts@2021-04-01' = {
+  name: 'storage${resourceToken}'
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    supportsHttpsTrafficOnly: true
+  }
+}
+
+// Provision Table Service
+resource tableService 'Microsoft.Storage/storageAccounts/tableServices@2021-04-01' = {
+  parent: storageAccount
+  name: 'default'
+}
+
+// Provision Table Storage
+resource table 'Microsoft.Storage/storageAccounts/tableServices/tables@2021-04-01' = {
+  parent: tableService
+  name: 'mytable'
+}
+
 // Add outputs from the deployment here, if needed.
 //
 // This allows the outputs to be referenced by other bicep deployments in the deployment pipeline,
@@ -67,3 +92,7 @@ output AZURE_TENANT_ID string = tenant().tenantId
 
 output AZURE_KEYVAULT_NAME string = keyVault.outputs.name
 output AZURE_KEYVAULT_ENDPOINT string = keyVault.outputs.endpoint
+
+output AZURE_STORAGE_ACCOUNT_NAME string = storageAccount.name
+output AZURE_STORAGE_ACCOUNT_TABLE_NAME string = table.name
+//TODO: connection string을 깃헙 액션으로 안전하게 전달하기

--- a/src/AzureOpenAIProxy.ApiApp/AzureOpenAIProxy.ApiApp.csproj
+++ b/src/AzureOpenAIProxy.ApiApp/AzureOpenAIProxy.ApiApp.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.AI.OpenAI" Version="$(AzureOpenAIVersion)" />
+    <PackageReference Include="Azure.Data.Tables" Version="12.9.0" />
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="$(AspNetCoreVersion)" />

--- a/src/AzureOpenAIProxy.ApiApp/Program.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Program.cs
@@ -1,3 +1,5 @@
+using Azure.Data.Tables;
+
 using AzureOpenAIProxy.ApiApp.Endpoints;
 using AzureOpenAIProxy.ApiApp.Extensions;
 
@@ -13,6 +15,18 @@ builder.Services.AddOpenAIService();
 
 // Add OpenAPI service
 builder.Services.AddOpenApiService();
+
+builder.Services.AddSingleton<TableServiceClient>(sp =>
+{
+    //TODO: StorageAccount를 bicep으로 배포하기 (지금은 az 명령어로 수동생성함)
+    //TODO: connection string을 apphost에서 넘겨받기
+    //TODO: connection string을 StorageAccount 배포중에 넘겨받아서 안전하게 전달/관리하기
+    // 그 전까지는 appsettings.json에서 connection string을 가져오자
+    var configuration = sp.GetRequiredService<IConfiguration>();
+    var connectionString = configuration["Azure:StorageAccount:ConnectionString"]; //TODO: 이게맞나? 리팩토링 고민
+
+    return new TableServiceClient(connectionString);
+});
 
 var app = builder.Build();
 

--- a/src/AzureOpenAIProxy.ApiApp/appsettings.Development.sample.json
+++ b/src/AzureOpenAIProxy.ApiApp/appsettings.Development.sample.json
@@ -22,6 +22,10 @@
     "KeyVault": {
       "VaultUri": "https://{{key-vault-name}}.vault.azure.net/",
       "SecretName": "azure-openai-instances"
+    },
+    "StorageAccount": {
+      "ConnectionString": "DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName={AccountName};AccountKey={AccountKey};BlobEndpoint={BlobEndpoint};FileEndpoint={FileEndpoint};QueueEndpoint={QueueEndpoint};TableEndpoint={TableEndpoint}",
+      "ContainerName": ""
     }
   }
 }

--- a/src/AzureOpenAIProxy.ApiApp/appsettings.json
+++ b/src/AzureOpenAIProxy.ApiApp/appsettings.json
@@ -26,6 +26,10 @@
     "KeyVault": {
       "VaultUri": "https://{{key-vault-name}}.vault.azure.net/",
       "SecretName": "azure-openai-instances"
+    },
+    "StorageAccount": {
+      "ConnectionString": "",
+      "ContainerName": ""
     }
   },
 


### PR DESCRIPTION
진행상황을 공유하기 위한 PR 제출입니다.

- 진행한 것
  - 명령어를 사용해 테이블 스토리지 생성 `az storage account create -n tae0ymanulstorage -g rg-tae0y -l koreacentral --subscription ossca`
  - 커넥션 스트링을 우선 `appsettings`에서 참조, 서비스는 `Program`에서 생성하여 의존성 주입
  - 데이터 생성시 파티션키, 로우키에 대한 고민
- 하지 못한 것
  - 테이블 스토리지를 bicep/깃헙액션을 통해 배포하기 : 지금은 bicep에 추가했지만 `azd up`으로 배포되지 않음 
  - ITableEntity 인터페이스를 구현하기
  - 테스트!