### PR TITLE
[Admin] Add Test Codes for AddTableStorageService

### DIFF
--- a/test/AzureOpenAIProxy.ApiApp.Tests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/test/AzureOpenAIProxy.ApiApp.Tests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -1,4 +1,6 @@
-﻿using Azure.Security.KeyVault.Secrets;
+﻿using Azure;
+using Azure.Data.Tables;
+using Azure.Security.KeyVault.Secrets;
 
 using AzureOpenAIProxy.ApiApp.Extensions;
 
@@ -6,6 +8,8 @@ using FluentAssertions;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+
+using NSubstitute;
 
 namespace AzureOpenAIProxy.ApiApp.Tests.Extensions;
 
@@ -205,5 +209,158 @@ public class ServiceCollectionExtensionsTests
 
         // Assert
         result?.VaultUri.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void Given_ServiceCollection_When_Invoked_AddTableStorageService_Then_It_Should_Contain_TableServiceClient()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddTableStorageService();
+
+        // Assert
+        services.SingleOrDefault(p => p.ServiceType == typeof(TableServiceClient)).Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Given_ServiceCollection_When_Invoked_AddTableStorageService_Then_It_Should_Throw_Exception()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddTableStorageService();
+
+        // Act
+        Action action = () => services.BuildServiceProvider().GetService<TableServiceClient>();
+
+        // Assert
+        action.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Given_Empty_AzureSettings_When_Invoked_AddTableStorageService_Then_It_Should_Throw_Exception()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var dict = new Dictionary<string, string>()
+        {
+            { "Azure", string.Empty},
+        };
+#pragma warning disable CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
+        var config = new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+#pragma warning restore CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
+        services.AddSingleton<IConfiguration>(config);
+        services.AddTableStorageService();
+
+        // Act
+        Action action = () => services.BuildServiceProvider().GetService<TableServiceClient>();
+
+        // Assert
+        action.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Given_Empty_KeyVaultSettings_When_Invoked_AddTableStorageService_Then_It_Should_Throw_Exception()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var dict = new Dictionary<string, string>()
+        {
+            { "Azure:KeyVault", string.Empty },
+        };
+#pragma warning disable CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
+        var config = new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+#pragma warning restore CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
+        services.AddSingleton<IConfiguration>(config);
+        services.AddTableStorageService();
+
+        // Act
+        Action action = () => services.BuildServiceProvider().GetService<TableServiceClient>();
+
+        // Assert
+        action.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Given_Missing_SecretClient_When_Invoked_AddTableStorageService_Then_It_Should_Throw_Exception()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var dict = new Dictionary<string, string>()
+        {
+            { "Azure:KeyVault:SecretNames:Storage", "secret-name" },
+        };
+#pragma warning disable CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
+        var config = new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+#pragma warning restore CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
+        services.AddSingleton<IConfiguration>(config);
+        services.AddTableStorageService();
+
+        // Act
+        Action action = () => services.BuildServiceProvider().GetService<TableServiceClient>();
+
+        // Assert
+        action.Should().Throw<InvalidOperationException>();
+    }
+
+    [Theory]
+    [InlineData(default(string), typeof(KeyNotFoundException))]
+    [InlineData("", typeof(InvalidOperationException))]
+    public void Given_NullOrEmpty_SecretName_When_Invoked_AddTableStorageService_Then_It_Shoud_Throw_Exception(string? secretName, Type exceptionType)
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var dict = new Dictionary<string, string>()
+        {
+            { "Azure:KeyVault:SecretNames:Storage", secretName },
+        };
+#pragma warning disable CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
+        var config = new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+#pragma warning restore CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
+        services.AddSingleton<IConfiguration>(config);
+
+        var sc = Substitute.For<SecretClient>();
+        services.AddSingleton(sc);
+
+        services.AddTableStorageService();
+
+        // Act
+        Action action = () => services.BuildServiceProvider().GetService<TableServiceClient>();
+
+        // Assert
+        action.Should().Throw<Exception>().Which.Should().BeOfType(exceptionType);
+    }
+
+    [Theory]
+    [InlineData("secret-name", "DefaultEndpointsProtocol=https;AccountName=account;AccountKey=ZmFrZWtleQ==;EndpointSuffix=core.windows.net")]
+    public void Given_AppSettings_When_Invoked_AddTableStorageService_Then_It_Should_Return_TableServiceClient(string secretName, string connectionString)
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var dict = new Dictionary<string, string>()
+        {
+            { "Azure:KeyVault:SecretNames:Storage", secretName },
+        };
+#pragma warning disable CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
+        var config = new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+#pragma warning restore CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
+        services.AddSingleton<IConfiguration>(config);
+
+        var sc = Substitute.For<SecretClient>();
+        var sp = new SecretProperties(secretName);
+        var secret = SecretModelFactory.KeyVaultSecret(sp,connectionString);
+
+        sc.GetSecret(secretName).Returns(Response.FromValue(secret, Substitute.For<Response>()));
+        services.AddSingleton(sc);
+
+        services.AddTableStorageService();
+
+        // Act
+        var result = services.BuildServiceProvider().GetService<TableServiceClient>();
+
+        // Assert
+        result.Should().NotBeNull()
+                    .And.BeOfType<TableServiceClient>();
     }
 }


### PR DESCRIPTION
* Resolves: #300 
* Related to: #299 

---
### Subscription
* ApiApp의 ServiceCollectionExtensions.cs에 있는 AddTableStorageService에 대한 테스트코드 입니다.
https://github.com/aliencube/azure-openai-sdk-proxy/blob/999dfd708a5734b2a589f2ac8a4f287589a65f21/src/AzureOpenAIProxy.ApiApp/Extensions/ServiceCollectionExtensions.cs#L144-L169

### Discussion
* AddTableStorageService에서 ConnectionString에 대한 Validation 체크를 할 필요가 없나요? 아니면 @tae0y 님이 작업하신 부분에서 체크가 돼서 KeyVault에 저장되고 있는 상황인 건가요?