### PR TITLE
[OpenAPI] Refactor AdminGetEventDetailsOpenApiTests to use InlineData for test cases

### DIFF
--- a/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEndpointUrls.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminEndpointUrls.cs
@@ -22,4 +22,12 @@ public static class AdminEndpointUrls
     /// - POST method for new event creation
     /// </remarks>
     public const string AdminEvents = "/admin/events";
+
+    /// <summary>
+    /// Declares the admin resource details endpoint.
+    /// </summary>
+    /// <remarks>
+    /// - POST method for new resource creation
+    /// </remarks>
+    public const string AdminResources = "/admin/resources";
 }

--- a/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminResourceEndpoints.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Endpoints/AdminResourceEndpoints.cs
@@ -1,0 +1,54 @@
+using AzureOpenAIProxy.ApiApp.Models;
+using AzureOpenAIProxy.ApiApp.Services;
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace AzureOpenAIProxy.ApiApp.Endpoints;
+
+/// <summary>
+/// This represents the endpoint entity for resource details by admin
+/// </summary>
+public static class AdminResourceEndpoints
+{
+    /// <summary>
+    /// Adds the admin resource endpoint
+    /// </summary>
+    /// <param name="app"><see cref="WebApplication"/> instance.</param>
+    /// <returns>Returns <see cref="RouteHandlerBuilder"/> instance.</returns>
+    public static RouteHandlerBuilder AddNewAdminResource(this WebApplication app)
+    {
+        var builder = app.MapPost(AdminEndpointUrls.AdminResources, async (
+            [FromBody] AdminResourceDetails payload,
+            IAdminEventService service,
+            ILoggerFactory loggerFactory) =>
+        {
+            var logger = loggerFactory.CreateLogger(nameof(AdminResourceEndpoints));
+            logger.LogInformation("Received a new resource request");
+
+            if (payload is null)
+            {
+                logger.LogError("No payload found");
+
+                return Results.BadRequest("Payload is null");
+            }
+
+            return await Task.FromResult(Results.Ok());
+        })
+        .Accepts<AdminResourceDetails>(contentType: "application/json")
+        .Produces<AdminResourceDetails>(statusCode: StatusCodes.Status200OK, contentType: "application/json")
+        .Produces(statusCode: StatusCodes.Status400BadRequest)
+        .Produces(statusCode: StatusCodes.Status401Unauthorized)
+        .Produces<string>(statusCode: StatusCodes.Status500InternalServerError, contentType: "text/plain")
+        .WithTags("admin")
+        .WithName("CreateAdminResource")
+        .WithOpenApi(operation =>
+        {
+            operation.Summary = "Create admin resource";
+            operation.Description = "Create admin resource";
+
+            return operation;
+        });
+
+        return builder;
+    }
+}

--- a/src/AzureOpenAIProxy.ApiApp/Filters/OpenApiTagFilter.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Filters/OpenApiTagFilter.cs
@@ -16,7 +16,7 @@ public class OpenApiTagFilter : IDocumentFilter
         [
             new OpenApiTag { Name = "weather", Description = "Weather forecast operations" },
             new OpenApiTag { Name = "openai", Description = "Azure OpenAI operations" },
-            new OpenApiTag { Name = "admin", Description = "Admin for organizing events" },
+            new OpenApiTag { Name = "admin", Description = "Admin operations for managing events and resources" },
             new OpenApiTag { Name = "events", Description = "User events" }
         ];
     }

--- a/src/AzureOpenAIProxy.ApiApp/Program.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Program.cs
@@ -58,4 +58,6 @@ app.AddListAdminEvents();
 app.AddGetAdminEvent();
 app.AddUpdateAdminEvent();
 
+app.AddNewAdminResource();
+
 await app.RunAsync();

--- a/test/AzureOpenAIProxy.AppHost.Tests/ApiApp/Endpoints/AdminCreateResourcesOpenApiTests.cs
+++ b/test/AzureOpenAIProxy.AppHost.Tests/ApiApp/Endpoints/AdminCreateResourcesOpenApiTests.cs
@@ -4,6 +4,8 @@ using AzureOpenAIProxy.AppHost.Tests.Fixtures;
 
 using FluentAssertions;
 
+using IdentityModel.Client;
+
 namespace AzureOpenAIProxy.AppHost.Tests.ApiApp.Endpoints;
 
 public class AdminCreateResourcesOpenApiTests(AspireAppHostFixture host) : IClassFixture<AspireAppHostFixture>
@@ -39,7 +41,7 @@ public class AdminCreateResourcesOpenApiTests(AspireAppHostFixture host) : IClas
         // Assert
         var result = openapi!.RootElement.GetProperty("paths")
                                          .GetProperty("/admin/resources")
-                                         .TryGetProperty("post", out var property) ? property : default;
+                                         .GetProperty("post");
         result.ValueKind.Should().Be(JsonValueKind.Object);
     }
 
@@ -59,7 +61,7 @@ public class AdminCreateResourcesOpenApiTests(AspireAppHostFixture host) : IClas
         var result = openapi!.RootElement.GetProperty("paths")
                                          .GetProperty("/admin/resources")
                                          .GetProperty("post")
-                                         .TryGetProperty("tags", out var property) ? property : default;
+                                         .GetProperty("tags");
         result.ValueKind.Should().Be(JsonValueKind.Array);
         result.EnumerateArray().Select(p => p.GetString()).Should().Contain(tag);
     }
@@ -82,7 +84,7 @@ public class AdminCreateResourcesOpenApiTests(AspireAppHostFixture host) : IClas
         var result = openapi!.RootElement.GetProperty("paths")
                                          .GetProperty("/admin/resources")
                                          .GetProperty("post")
-                                         .TryGetProperty(attribute, out var property) ? property : default;
+                                         .GetProperty(attribute);
         result.ValueKind.Should().Be(JsonValueKind.String);
     }
 
@@ -103,7 +105,7 @@ public class AdminCreateResourcesOpenApiTests(AspireAppHostFixture host) : IClas
         var result = openapi!.RootElement.GetProperty("paths")
                                          .GetProperty("/admin/resources")
                                          .GetProperty("post")
-                                         .TryGetProperty(attribute, out var property) ? property : default;
+                                         .GetProperty(attribute);
         result.ValueKind.Should().Be(JsonValueKind.Object);
     }
 
@@ -127,7 +129,7 @@ public class AdminCreateResourcesOpenApiTests(AspireAppHostFixture host) : IClas
                                          .GetProperty("/admin/resources")
                                          .GetProperty("post")
                                          .GetProperty("responses")
-                                         .TryGetProperty(attribute, out var property) ? property : default;
+                                         .GetProperty(attribute);
         result.ValueKind.Should().Be(JsonValueKind.Object);
     }
 
@@ -144,7 +146,7 @@ public class AdminCreateResourcesOpenApiTests(AspireAppHostFixture host) : IClas
 
         // Assert
         var result = openapi!.RootElement.GetProperty("components")
-                                         .TryGetProperty("schemas", out var property) ? property : default;
+                                         .GetProperty("schemas");
         result.ValueKind.Should().Be(JsonValueKind.Object);
     }
 
@@ -162,7 +164,130 @@ public class AdminCreateResourcesOpenApiTests(AspireAppHostFixture host) : IClas
         // Assert
         var result = openapi!.RootElement.GetProperty("components")
                                          .GetProperty("schemas")
-                                         .TryGetProperty("AdminResourceDetails", out var property) ? property : default;
+                                         .GetProperty("AdminResourceDetails");
         result.ValueKind.Should().Be(JsonValueKind.Object);
+    }
+    
+    public static IEnumerable<object[]> AttributeData =>
+        [
+            ["resourceId", true, "string"],
+            ["friendlyName", true, "string"],
+            ["deploymentName", true, "string"],
+            ["resourceType", true, "string"],
+            ["endpoint", true, "string"],
+            ["apiKey", true, "string"],
+            ["region", true, "string"],
+            ["isActive", true, "boolean"]
+        ];
+
+    [Theory]
+    [MemberData(nameof(AttributeData))]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Required(string attribute, bool isRequired, string type)
+    {
+        // Arrange
+        using var httpClient = host.App!.CreateHttpClient("apiapp");
+        await host.ResourceNotificationService.WaitForResourceAsync("apiapp", KnownResourceStates.Running).WaitAsync(TimeSpan.FromSeconds(30));
+
+        // Act
+        var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
+        var openapi = JsonSerializer.Deserialize<JsonDocument>(json);
+
+        // Assert
+        var result = openapi!.RootElement.GetProperty("components")
+                                         .GetProperty("schemas")
+                                         .GetProperty("AdminResourceDetails")
+                                         .TryGetStringArray("required")
+                                         .ToList();
+        result.Contains(attribute).Should().Be(isRequired);
+    }
+
+    [Theory]
+    [MemberData(nameof(AttributeData))]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Property(string attribute, bool isRequired, string type)
+    {
+        // Arrange
+        using var httpClient = host.App!.CreateHttpClient("apiapp");
+        await host.ResourceNotificationService.WaitForResourceAsync("apiapp", KnownResourceStates.Running).WaitAsync(TimeSpan.FromSeconds(30));
+
+        // Act
+        var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
+        var openapi = JsonSerializer.Deserialize<JsonDocument>(json);
+
+        // Assert
+        var result = openapi!.RootElement.GetProperty("components")
+                                         .GetProperty("schemas")
+                                         .GetProperty("AdminResourceDetails")
+                                         .GetProperty("properties")
+                                         .GetProperty(attribute);
+        result.ValueKind.Should().Be(JsonValueKind.Object);
+    }
+
+    [Theory]
+    [MemberData(nameof(AttributeData))]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Type(string attribute, bool isRequired, string type)
+    {
+        // Arrange
+        using var httpClient = host.App!.CreateHttpClient("apiapp");
+        await host.ResourceNotificationService.WaitForResourceAsync("apiapp", KnownResourceStates.Running).WaitAsync(TimeSpan.FromSeconds(30));
+
+        // Act
+        var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
+        var openapi = JsonSerializer.Deserialize<JsonDocument>(json);
+
+        // Assert
+        var result = openapi!.RootElement.GetProperty("components")
+                                         .GetProperty("schemas")
+                                         .GetProperty("AdminResourceDetails")
+                                         .GetProperty("properties")
+                                         .GetProperty(attribute);
+
+        if (!result.TryGetProperty("type", out var typeProperty))
+        {
+            var refPath = result.TryGetString("$ref").TrimStart('#', '/').Split('/');
+            var refSchema = openapi.RootElement;
+
+            foreach (var part in refPath)
+            {
+                refSchema = refSchema.GetProperty(part);
+            }
+
+            typeProperty = refSchema.GetProperty("type");
+        }
+        
+        typeProperty.GetString().Should().Be(type);
+    }
+
+    [Fact]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Validate_ResourceType_As_Enum()
+    {
+        // Arrange
+        using var httpClient = host.App!.CreateHttpClient("apiapp");
+        await host.ResourceNotificationService.WaitForResourceAsync("apiapp", KnownResourceStates.Running).WaitAsync(TimeSpan.FromSeconds(30));
+
+        // Act
+        var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
+        var openapi = JsonSerializer.Deserialize<JsonDocument>(json);
+
+        // Assert
+        var result = openapi!.RootElement.GetProperty("components")
+                                         .GetProperty("schemas")
+                                         .GetProperty("AdminResourceDetails")
+                                         .GetProperty("properties")
+                                         .GetProperty("resourceType");
+
+        var refPath = result.TryGetString("$ref").TrimStart('#', '/').Split('/');
+        var refSchema = openapi.RootElement;
+
+        foreach (var part in refPath)
+        {
+            refSchema = refSchema.GetProperty(part);
+        }
+
+        var enumValues = refSchema.GetProperty("enum")
+                                  .EnumerateArray()
+                                  .Select(p => p.GetString())
+                                  .ToList();
+
+        enumValues.Should().BeEquivalentTo(["none", "chat", "image"]);
     }
 }

--- a/test/AzureOpenAIProxy.AppHost.Tests/ApiApp/Endpoints/AdminCreateResourcesOpenApiTests.cs
+++ b/test/AzureOpenAIProxy.AppHost.Tests/ApiApp/Endpoints/AdminCreateResourcesOpenApiTests.cs
@@ -168,21 +168,16 @@ public class AdminCreateResourcesOpenApiTests(AspireAppHostFixture host) : IClas
         result.ValueKind.Should().Be(JsonValueKind.Object);
     }
     
-    public static IEnumerable<object[]> AttributeData =>
-        [
-            ["resourceId", true, "string"],
-            ["friendlyName", true, "string"],
-            ["deploymentName", true, "string"],
-            ["resourceType", true, "string"],
-            ["endpoint", true, "string"],
-            ["apiKey", true, "string"],
-            ["region", true, "string"],
-            ["isActive", true, "boolean"]
-        ];
-
     [Theory]
-    [MemberData(nameof(AttributeData))]
-    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Required(string attribute, bool isRequired, string type)
+    [InlineData("resourceId", true)]
+    [InlineData("friendlyName", true)]
+    [InlineData("deploymentName", true)]
+    [InlineData("resourceType", true)]
+    [InlineData("endpoint", true)]
+    [InlineData("apiKey", true)]
+    [InlineData("region", true)]
+    [InlineData("isActive", true)]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Required(string attribute, bool isRequired)
     {
         // Arrange
         using var httpClient = host.App!.CreateHttpClient("apiapp");
@@ -202,8 +197,15 @@ public class AdminCreateResourcesOpenApiTests(AspireAppHostFixture host) : IClas
     }
 
     [Theory]
-    [MemberData(nameof(AttributeData))]
-    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Property(string attribute, bool isRequired, string type)
+    [InlineData("resourceId")]
+    [InlineData("friendlyName")]
+    [InlineData("deploymentName")]
+    [InlineData("resourceType")]
+    [InlineData("endpoint")]
+    [InlineData("apiKey")]
+    [InlineData("region")]
+    [InlineData("isActive")]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Property(string attribute)
     {
         // Arrange
         using var httpClient = host.App!.CreateHttpClient("apiapp");
@@ -223,8 +225,15 @@ public class AdminCreateResourcesOpenApiTests(AspireAppHostFixture host) : IClas
     }
 
     [Theory]
-    [MemberData(nameof(AttributeData))]
-    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Type(string attribute, bool isRequired, string type)
+    [InlineData("resourceId", "string")]
+    [InlineData("friendlyName", "string")]
+    [InlineData("deploymentName", "string")]
+    [InlineData("resourceType", "string")]
+    [InlineData("endpoint", "string")]
+    [InlineData("apiKey", "string")]
+    [InlineData("region", "string")]
+    [InlineData("isActive", "boolean")]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Type(string attribute, string type)
     {
         // Arrange
         using var httpClient = host.App!.CreateHttpClient("apiapp");

--- a/test/AzureOpenAIProxy.AppHost.Tests/ApiApp/Endpoints/AdminCreateResourcesOpenApiTests.cs
+++ b/test/AzureOpenAIProxy.AppHost.Tests/ApiApp/Endpoints/AdminCreateResourcesOpenApiTests.cs
@@ -1,0 +1,168 @@
+using System.Text.Json;
+
+using AzureOpenAIProxy.AppHost.Tests.Fixtures;
+
+using FluentAssertions;
+
+namespace AzureOpenAIProxy.AppHost.Tests.ApiApp.Endpoints;
+
+public class AdminCreateResourcesOpenApiTests(AspireAppHostFixture host) : IClassFixture<AspireAppHostFixture>
+{
+    [Fact]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Path()
+    {
+        // Arrange
+        using var httpClient = host.App!.CreateHttpClient("apiapp");
+        await host.ResourceNotificationService.WaitForResourceAsync("apiapp", KnownResourceStates.Running).WaitAsync(TimeSpan.FromSeconds(30));
+
+        // Act
+        var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
+        var openapi = JsonSerializer.Deserialize<JsonDocument>(json);
+
+        // Assert
+        var result = openapi!.RootElement.GetProperty("paths")
+                                         .GetProperty("/admin/resources");
+        result.ValueKind.Should().Be(JsonValueKind.Object);
+    }
+
+    [Fact]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Verb()
+    {
+        // Arrange
+        using var httpClient = host.App!.CreateHttpClient("apiapp");
+        await host.ResourceNotificationService.WaitForResourceAsync("apiapp", KnownResourceStates.Running).WaitAsync(TimeSpan.FromSeconds(30));
+
+        // Act
+        var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
+        var openapi = JsonSerializer.Deserialize<JsonDocument>(json);
+
+        // Assert
+        var result = openapi!.RootElement.GetProperty("paths")
+                                         .GetProperty("/admin/resources")
+                                         .TryGetProperty("post", out var property) ? property : default;
+        result.ValueKind.Should().Be(JsonValueKind.Object);
+    }
+
+    [Theory]
+    [InlineData("admin")]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Tags(string tag)
+    {
+        // Arrange
+        using var httpClient = host.App!.CreateHttpClient("apiapp");
+        await host.ResourceNotificationService.WaitForResourceAsync("apiapp", KnownResourceStates.Running).WaitAsync(TimeSpan.FromSeconds(30));
+
+        // Act
+        var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
+        var openapi = JsonSerializer.Deserialize<JsonDocument>(json);
+
+        // Assert
+        var result = openapi!.RootElement.GetProperty("paths")
+                                         .GetProperty("/admin/resources")
+                                         .GetProperty("post")
+                                         .TryGetProperty("tags", out var property) ? property : default;
+        result.ValueKind.Should().Be(JsonValueKind.Array);
+        result.EnumerateArray().Select(p => p.GetString()).Should().Contain(tag);
+    }
+
+    [Theory]
+    [InlineData("summary")]
+    [InlineData("description")]
+    [InlineData("operationId")]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Value(string attribute)
+    {
+        // Arrange
+        using var httpClient = host.App!.CreateHttpClient("apiapp");
+        await host.ResourceNotificationService.WaitForResourceAsync("apiapp", KnownResourceStates.Running).WaitAsync(TimeSpan.FromSeconds(30));
+
+        // Act
+        var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
+        var openapi = JsonSerializer.Deserialize<JsonDocument>(json);
+
+        // Assert
+        var result = openapi!.RootElement.GetProperty("paths")
+                                         .GetProperty("/admin/resources")
+                                         .GetProperty("post")
+                                         .TryGetProperty(attribute, out var property) ? property : default;
+        result.ValueKind.Should().Be(JsonValueKind.String);
+    }
+
+    [Theory]
+    [InlineData("requestBody")]
+    [InlineData("responses")]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Object(string attribute)
+    {
+        // Arrange
+        using var httpClient = host.App!.CreateHttpClient("apiapp");
+        await host.ResourceNotificationService.WaitForResourceAsync("apiapp", KnownResourceStates.Running).WaitAsync(TimeSpan.FromSeconds(30));
+
+        // Act
+        var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
+        var openapi = JsonSerializer.Deserialize<JsonDocument>(json);
+
+        // Assert
+        var result = openapi!.RootElement.GetProperty("paths")
+                                         .GetProperty("/admin/resources")
+                                         .GetProperty("post")
+                                         .TryGetProperty(attribute, out var property) ? property : default;
+        result.ValueKind.Should().Be(JsonValueKind.Object);
+    }
+
+    [Theory]
+    [InlineData("200")]
+    [InlineData("400")]
+    [InlineData("401")]
+    [InlineData("500")]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Response(string attribute)
+    {
+        // Arrange
+        using var httpClient = host.App!.CreateHttpClient("apiapp");
+        await host.ResourceNotificationService.WaitForResourceAsync("apiapp", KnownResourceStates.Running).WaitAsync(TimeSpan.FromSeconds(30));
+
+        // Act
+        var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
+        var openapi = JsonSerializer.Deserialize<JsonDocument>(json);
+
+        // Assert
+        var result = openapi!.RootElement.GetProperty("paths")
+                                         .GetProperty("/admin/resources")
+                                         .GetProperty("post")
+                                         .GetProperty("responses")
+                                         .TryGetProperty(attribute, out var property) ? property : default;
+        result.ValueKind.Should().Be(JsonValueKind.Object);
+    }
+
+    [Fact]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Schemas()
+    {
+        // Arrange
+        using var httpClient = host.App!.CreateHttpClient("apiapp");
+        await host.ResourceNotificationService.WaitForResourceAsync("apiapp", KnownResourceStates.Running).WaitAsync(TimeSpan.FromSeconds(30));
+
+        // Act
+        var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
+        var openapi = JsonSerializer.Deserialize<JsonDocument>(json);
+
+        // Assert
+        var result = openapi!.RootElement.GetProperty("components")
+                                         .TryGetProperty("schemas", out var property) ? property : default;
+        result.ValueKind.Should().Be(JsonValueKind.Object);
+    }
+
+    [Fact]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Model()
+    {
+        // Arrange
+        using var httpClient = host.App!.CreateHttpClient("apiapp");
+        await host.ResourceNotificationService.WaitForResourceAsync("apiapp", KnownResourceStates.Running).WaitAsync(TimeSpan.FromSeconds(30));
+
+        // Act
+        var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
+        var openapi = JsonSerializer.Deserialize<JsonDocument>(json);
+
+        // Assert
+        var result = openapi!.RootElement.GetProperty("components")
+                                         .GetProperty("schemas")
+                                         .TryGetProperty("AdminResourceDetails", out var property) ? property : default;
+        result.ValueKind.Should().Be(JsonValueKind.Object);
+    }
+}

--- a/test/AzureOpenAIProxy.AppHost.Tests/ApiApp/Endpoints/AdminGetEventDetailsOpenApiTests.cs
+++ b/test/AzureOpenAIProxy.AppHost.Tests/ApiApp/Endpoints/AdminGetEventDetailsOpenApiTests.cs
@@ -174,24 +174,6 @@ public class AdminGetEventDetailsOpenApiTests(AspireAppHostFixture host) : IClas
         result.ValueKind.Should().Be(JsonValueKind.Object);
     }
 
-    public static IEnumerable<object[]> AttributeData =>
-        [
-            ["eventId", true, "string"],
-            ["title", true, "string"],
-            ["summary", true, "string"],
-            ["description", false, "string"],
-            ["dateStart", true, "string"],
-            ["dateEnd", true, "string"],
-            ["timeZone", true, "string"],
-            ["isActive", true, "boolean"],
-            ["organizerName", true, "string"],
-            ["organizerEmail", true, "string"],
-            ["coorganizerName", false, "string"],
-            ["coorganizerEmail", false, "string"],
-            ["maxTokenCap", true, "integer"],
-            ["dailyRequestCap", true, "integer"]
-        ];
-
     [Fact]
     public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Schemas()
     {
@@ -228,15 +210,25 @@ public class AdminGetEventDetailsOpenApiTests(AspireAppHostFixture host) : IClas
     }
 
     [Theory]
-    [MemberData(nameof(AttributeData))]
-    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Required(string attribute, bool isRequired, string type)
+    [InlineData("eventId", true)]
+    [InlineData("title", true)]
+    [InlineData("summary", true)]
+    [InlineData("description", false)]
+    [InlineData("dateStart", true)]
+    [InlineData("dateEnd", true)]
+    [InlineData("timeZone", true)]
+    [InlineData("isActive", true)]
+    [InlineData("organizerName", true)]
+    [InlineData("organizerEmail", true)]
+    [InlineData("coorganizerName", false)]
+    [InlineData("coorganizerEmail", false)]
+    [InlineData("maxTokenCap", true)]
+    [InlineData("dailyRequestCap", true)]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Required(string attribute, bool isRequired)
     {
         // Arrange
         using var httpClient = host.App!.CreateHttpClient("apiapp");
         await host.ResourceNotificationService.WaitForResourceAsync("apiapp", KnownResourceStates.Running).WaitAsync(TimeSpan.FromSeconds(30));
-
-        var isReq = isRequired;
-        var typeStr = type;
 
         // Act
         var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
@@ -252,15 +244,25 @@ public class AdminGetEventDetailsOpenApiTests(AspireAppHostFixture host) : IClas
     }
 
     [Theory]
-    [MemberData(nameof(AttributeData))]
-    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Property(string attribute, bool isRequired, string type)
+    [InlineData("eventId")]
+    [InlineData("title")]
+    [InlineData("summary")]
+    [InlineData("description")]
+    [InlineData("dateStart")]
+    [InlineData("dateEnd")]
+    [InlineData("timeZone")]
+    [InlineData("isActive")]
+    [InlineData("organizerName")]
+    [InlineData("organizerEmail")]
+    [InlineData("coorganizerName")]
+    [InlineData("coorganizerEmail")]
+    [InlineData("maxTokenCap")]
+    [InlineData("dailyRequestCap")]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Property(string attribute)
     {
         // Arrange
         using var httpClient = host.App!.CreateHttpClient("apiapp");
         await host.ResourceNotificationService.WaitForResourceAsync("apiapp", KnownResourceStates.Running).WaitAsync(TimeSpan.FromSeconds(30));
-
-        var isReq = isRequired;
-        var typeStr = type;
 
         // Act
         var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
@@ -276,15 +278,25 @@ public class AdminGetEventDetailsOpenApiTests(AspireAppHostFixture host) : IClas
     }
 
     [Theory]
-    [MemberData(nameof(AttributeData))]
-    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Type(string attribute, bool isRequired, string type)
+    [InlineData("eventId", "string")]
+    [InlineData("title", "string")]
+    [InlineData("summary", "string")]
+    [InlineData("description", "string")]
+    [InlineData("dateStart", "string")]
+    [InlineData("dateEnd", "string")]
+    [InlineData("timeZone", "string")]
+    [InlineData("isActive", "boolean")]
+    [InlineData("organizerName", "string")]
+    [InlineData("organizerEmail", "string")]
+    [InlineData("coorganizerName", "string")]
+    [InlineData("coorganizerEmail", "string")]
+    [InlineData("maxTokenCap", "integer")]
+    [InlineData("dailyRequestCap", "integer")]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Type(string attribute, string type)
     {
         // Arrange
         using var httpClient = host.App!.CreateHttpClient("apiapp");
         await host.ResourceNotificationService.WaitForResourceAsync("apiapp", KnownResourceStates.Running).WaitAsync(TimeSpan.FromSeconds(30));
-
-        var isReq = isRequired;
-        var typeStr = type;
 
         // Act
         var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");


### PR DESCRIPTION
#207 팔로업 PR

## Description

테스트 메서드에서 사용되지 않는 파라미터들이 전달되는 문제를 해결하고, 코드를 간결하게 개선했습니다.

## Summary of Changes

- `[MemberData]`에서 `[InlineData]`로 변경: 각 테스트에 필요한 데이터만 직접 제공하도록 [MemberData] 대신 [InlineData]를 사용했습니다.

- 불필요한 파라미터 제거: 테스트 메서드에서 사용되지 않는 파라미터를 제거하여 인터페이스를 단순화하고, 실제로 필요한 데이터만 처리하도록 개선했습니다.

### 변경 전

```csharp
public static IEnumerable<object[]> AttributeData =>
    [
        ["eventId", true, "string"],
        ["title", true, "string"],
        // 추가 항목 생략
    ];

[Theory]
[MemberData(nameof(AttributeData))]
public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Property(string attribute, bool isRequired, string type)
{
    // Arrange
    using var httpClient = host.App!.CreateHttpClient("apiapp");
    await host.ResourceNotificationService.WaitForResourceAsync("apiapp", KnownResourceStates.Running).WaitAsync(TimeSpan.FromSeconds(30));

    var isReq = isRequired; // 불필요한 변수 할당
    var typeStr = type;     // 불필요한 변수 할당

    // Act & Assert 생략
}
```

### 변경 후

```csharp
[Theory]
[InlineData("eventId")]
[InlineData("title")]
// 추가 항목 생략
public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Property(string attribute)
{
    // Arrange
    using var httpClient = host.App!.CreateHttpClient("apiapp");
    await host.ResourceNotificationService.WaitForResourceAsync("apiapp", KnownResourceStates.Running).WaitAsync(TimeSpan.FromSeconds(30));

    // Act & Assert 생략
}
```