### PR TITLE
[OpenAPI] Refactoring `AdminGetEventDetailsOpenApiTests`

### DIFF
--- a/test/AzureOpenAIProxy.AppHost.Tests/ApiApp/Endpoints/AdminGetEventDetailsOpenApiTests.cs
+++ b/test/AzureOpenAIProxy.AppHost.Tests/ApiApp/Endpoints/AdminGetEventDetailsOpenApiTests.cs
@@ -174,24 +174,6 @@ public class AdminGetEventDetailsOpenApiTests(AspireAppHostFixture host) : IClas
         result.ValueKind.Should().Be(JsonValueKind.Object);
     }
 
-    public static IEnumerable<object[]> AttributeData =>
-        [
-            ["eventId", true, "string"],
-            ["title", true, "string"],
-            ["summary", true, "string"],
-            ["description", false, "string"],
-            ["dateStart", true, "string"],
-            ["dateEnd", true, "string"],
-            ["timeZone", true, "string"],
-            ["isActive", true, "boolean"],
-            ["organizerName", true, "string"],
-            ["organizerEmail", true, "string"],
-            ["coorganizerName", false, "string"],
-            ["coorganizerEmail", false, "string"],
-            ["maxTokenCap", true, "integer"],
-            ["dailyRequestCap", true, "integer"]
-        ];
-
     [Fact]
     public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Schemas()
     {
@@ -228,15 +210,25 @@ public class AdminGetEventDetailsOpenApiTests(AspireAppHostFixture host) : IClas
     }
 
     [Theory]
-    [MemberData(nameof(AttributeData))]
-    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Required(string attribute, bool isRequired, string type)
+    [InlineData("eventId", true)]
+    [InlineData("title", true)]
+    [InlineData("summary", true)]
+    [InlineData("description", false)]
+    [InlineData("dateStart", true)]
+    [InlineData("dateEnd", true)]
+    [InlineData("timeZone", true)]
+    [InlineData("isActive", true)]
+    [InlineData("organizerName", true)]
+    [InlineData("organizerEmail", true)]
+    [InlineData("coorganizerName", false)]
+    [InlineData("coorganizerEmail", false)]
+    [InlineData("maxTokenCap", true)]
+    [InlineData("dailyRequestCap", true)]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Required(string attribute, bool isRequired)
     {
         // Arrange
         using var httpClient = host.App!.CreateHttpClient("apiapp");
         await host.ResourceNotificationService.WaitForResourceAsync("apiapp", KnownResourceStates.Running).WaitAsync(TimeSpan.FromSeconds(30));
-
-        var isReq = isRequired;
-        var typeStr = type;
 
         // Act
         var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
@@ -252,15 +244,25 @@ public class AdminGetEventDetailsOpenApiTests(AspireAppHostFixture host) : IClas
     }
 
     [Theory]
-    [MemberData(nameof(AttributeData))]
-    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Property(string attribute, bool isRequired, string type)
+    [InlineData("eventId")]
+    [InlineData("title")]
+    [InlineData("summary")]
+    [InlineData("description")]
+    [InlineData("dateStart")]
+    [InlineData("dateEnd")]
+    [InlineData("timeZone")]
+    [InlineData("isActive")]
+    [InlineData("organizerName")]
+    [InlineData("organizerEmail")]
+    [InlineData("coorganizerName")]
+    [InlineData("coorganizerEmail")]
+    [InlineData("maxTokenCap")]
+    [InlineData("dailyRequestCap")]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Property(string attribute)
     {
         // Arrange
         using var httpClient = host.App!.CreateHttpClient("apiapp");
         await host.ResourceNotificationService.WaitForResourceAsync("apiapp", KnownResourceStates.Running).WaitAsync(TimeSpan.FromSeconds(30));
-
-        var isReq = isRequired;
-        var typeStr = type;
 
         // Act
         var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");
@@ -276,15 +278,25 @@ public class AdminGetEventDetailsOpenApiTests(AspireAppHostFixture host) : IClas
     }
 
     [Theory]
-    [MemberData(nameof(AttributeData))]
-    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Type(string attribute, bool isRequired, string type)
+    [InlineData("eventId", "string")]
+    [InlineData("title", "string")]
+    [InlineData("summary", "string")]
+    [InlineData("description", "string")]
+    [InlineData("dateStart", "string")]
+    [InlineData("dateEnd", "string")]
+    [InlineData("timeZone", "string")]
+    [InlineData("isActive", "boolean")]
+    [InlineData("organizerName", "string")]
+    [InlineData("organizerEmail", "string")]
+    [InlineData("coorganizerName", "string")]
+    [InlineData("coorganizerEmail", "string")]
+    [InlineData("maxTokenCap", "integer")]
+    [InlineData("dailyRequestCap", "integer")]
+    public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Type(string attribute, string type)
     {
         // Arrange
         using var httpClient = host.App!.CreateHttpClient("apiapp");
         await host.ResourceNotificationService.WaitForResourceAsync("apiapp", KnownResourceStates.Running).WaitAsync(TimeSpan.FromSeconds(30));
-
-        var isReq = isRequired;
-        var typeStr = type;
 
         // Act
         var json = await httpClient.GetStringAsync("/swagger/v1.0.0/swagger.json");


### PR DESCRIPTION
#207 팔로업 PR

## Description

테스트 메서드에서 사용되지 않는 파라미터들이 전달되는 문제 해결

## Summary of Changes

- `[MemberData]`에서 `[InlineData]`로 변경: 각 테스트에 필요한 데이터만 직접 제공하도록 [MemberData] 대신 [InlineData]를 사용

- 불필요한 파라미터 제거: 테스트 메서드에서 사용되지 않는 파라미터를 제거하여 인터페이스를 단순화하고, 필요한 데이터만 처리하도록 개선

### Before

```csharp
public static IEnumerable<object[]> AttributeData =>
    [
        ["eventId", true, "string"],
        ["title", true, "string"],
        // 나머지 데이터 생략
    ];

[Theory]
[MemberData(nameof(AttributeData))]
public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Property(string attribute, bool isRequired, string type)
{
    // Arrange
    using var httpClient = host.App!.CreateHttpClient("apiapp");
    await host.ResourceNotificationService.WaitForResourceAsync("apiapp", KnownResourceStates.Running).WaitAsync(TimeSpan.FromSeconds(30));

    var isReq = isRequired; // 불필요한 변수 할당
    var typeStr = type;     // 불필요한 변수 할당

    // Act & Assert 생략
}
```

### After

```csharp
[Theory]
[InlineData("eventId")]
[InlineData("title")]
// 나머지 데이터 생략
public async Task Given_Resource_When_Invoked_Endpoint_Then_It_Should_Return_Property(string attribute)
{
    // Arrange
    using var httpClient = host.App!.CreateHttpClient("apiapp");
    await host.ResourceNotificationService.WaitForResourceAsync("apiapp", KnownResourceStates.Running).WaitAsync(TimeSpan.FromSeconds(30));

    // Act & Assert 생략
}
```