### PR TITLE
[Backend API] Implement endpoint for list event details

### DIFF
--- a/src/AzureOpenAIProxy.ApiApp/Extensions/ServiceCollectionExtensions.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Extensions/ServiceCollectionExtensions.cs
@@ -145,7 +145,7 @@ public static class ServiceCollectionExtensions
     {
         services.AddSingleton<TableServiceClient>(sp => {
             var configuration = sp.GetService<IConfiguration>()
-                ?? throw new InvalidOperationException($"{nameof(IConfiguration)} service is not registerd.");
+                ?? throw new InvalidOperationException($"{nameof(IConfiguration)} service is not registered.");
             
             var settings = configuration.GetSection(AzureSettings.Name).GetSection(KeyVaultSettings.Name).Get<KeyVaultSettings>()
                 ?? throw new InvalidOperationException($"{nameof(KeyVaultSettings)} could not be retrieved from the configuration.");

--- a/src/AzureOpenAIProxy.ApiApp/Repositories/AdminEventRepository.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Repositories/AdminEventRepository.cs
@@ -41,6 +41,13 @@ public interface IAdminEventRepository
     /// <param name="eventDetails">Event details instance.</param>
     /// <returns>Returns the updated record of the event details.</returns>
     Task<AdminEventDetails> UpdateEvent(Guid eventId, AdminEventDetails eventDetails);
+
+    /// <summary>
+    /// Deletes the event details.
+    /// </summary>
+    /// <param name="eventDetails">Event details instance.</param>
+    /// <returns>Removed EventID of event details instance.</returns>
+    Task<Guid> DeleteEvent(AdminEventDetails eventDetails);
 }
 
 /// <summary>
@@ -65,7 +72,6 @@ public class AdminEventRepository(TableServiceClient tableServiceClient, Storage
     public async Task<List<AdminEventDetails>> GetEvents()
     {
         var tableClient = await GetTableClientAsync();
-
         var eventDetailsList = new List<AdminEventDetails>();
 
         await foreach (var entity in tableClient.QueryAsync<AdminEventDetails>())
@@ -99,6 +105,15 @@ public class AdminEventRepository(TableServiceClient tableServiceClient, Storage
         await tableClient.UpdateEntityAsync<AdminEventDetails>(eventDetails, eventDetails.ETag, TableUpdateMode.Replace);
 
         return eventDetails;
+    }
+
+    public async Task<Guid> DeleteEvent(AdminEventDetails eventDetails)
+    {
+        var tableClient = await GetTableClientAsync();
+
+        await tableClient.DeleteEntityAsync(eventDetails.PartitionKey, eventDetails.RowKey);
+
+        return eventDetails.EventId;
     }
 
     private async Task<TableClient> GetTableClientAsync()

--- a/src/AzureOpenAIProxy.ApiApp/Services/AdminEventService.cs
+++ b/src/AzureOpenAIProxy.ApiApp/Services/AdminEventService.cs
@@ -35,6 +35,13 @@ public interface IAdminEventService
     /// <param name="eventDetails">Event details to update.</param>
     /// <returns>Returns the updated event details.</returns>
     Task<AdminEventDetails> UpdateEvent(Guid eventId, AdminEventDetails eventDetails);
+
+     /// <summary>
+    /// Deletes the event details.
+    /// </summary>
+    /// <param name="eventDetails">Event details to update.</param>
+    /// <returns>Removed EventID of event details instance.</returns>
+    Task<Guid> DeleteEvent(AdminEventDetails eventDetails);
 }
 
 /// <summary>
@@ -72,6 +79,14 @@ public class AdminEventService(IAdminEventRepository repository) : IAdminEventSe
     public async Task<AdminEventDetails> UpdateEvent(Guid eventId, AdminEventDetails eventDetails)
     {
         var result = await this._repository.UpdateEvent(eventId, eventDetails).ConfigureAwait(false);
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public async Task<Guid> DeleteEvent(AdminEventDetails eventDetails)
+    {
+        var result = await this._repository.DeleteEvent(eventDetails).ConfigureAwait(false);
 
         return result;
     }

--- a/test/AzureOpenAIProxy.ApiApp.Tests/Repositories/AdminEventRepositoryTests.cs
+++ b/test/AzureOpenAIProxy.ApiApp.Tests/Repositories/AdminEventRepositoryTests.cs
@@ -1,4 +1,6 @@
-﻿using Azure;
+﻿using System.Configuration;
+
+using Azure;
 using Azure.Data.Tables;
 
 using AzureOpenAIProxy.ApiApp.Configurations;
@@ -12,10 +14,25 @@ using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 
+using Xunit.Sdk;
+
 namespace AzureOpenAIProxy.ApiApp.Tests.Repositories;
 
 public class AdminEventRepositoryTests
 {
+    private StorageAccountSettings mockSettings;
+    private TableServiceClient mockTableServiceClient;
+    private TableClient mockTableClient;
+
+    public AdminEventRepositoryTests()
+    {
+        mockSettings = Substitute.For<StorageAccountSettings>();
+        mockTableServiceClient = Substitute.For<TableServiceClient>();
+        mockTableClient = Substitute.For<TableClient>();
+
+        mockTableServiceClient.GetTableClient(Arg.Any<string>()).Returns(mockTableClient);
+    }
+
     [Fact]
     public void Given_ServiceCollection_When_AddAdminEventRepository_Invoked_Then_It_Should_Contain_AdminEventRepository()
     {
@@ -33,11 +50,10 @@ public class AdminEventRepositoryTests
     public void Given_Null_TableServiceClient_When_Creating_AdminEventRepository_Then_It_Should_Throw_Exception()
     {
         // Arrange
-        var settings = Substitute.For<StorageAccountSettings>();
         var tableServiceClient = default(TableServiceClient);
         
         // Act
-        Action action = () => new AdminEventRepository(tableServiceClient, settings);
+        Action action = () => new AdminEventRepository(tableServiceClient, mockSettings);
 
         // Assert
         action.Should().Throw<ArgumentNullException>();
@@ -48,44 +64,39 @@ public class AdminEventRepositoryTests
     {
         // Arrange
         var settings = default(StorageAccountSettings);
-        var tableServiceClient = Substitute.For<TableServiceClient>();
         
         // Act
-        Action action = () => new AdminEventRepository(tableServiceClient, settings);
+        Action action = () => new AdminEventRepository(mockTableServiceClient, settings);
 
         // Assert
         action.Should().Throw<ArgumentNullException>();
     }
 
     [Fact]
-    public void Given_Instance_When_CreateEvent_Invoked_Then_It_Should_Throw_Exception()
+    public async Task Given_Instance_When_CreateEvent_Invoked_Then_It_Should_Return_Created_Event()
     {
         // Arrange
-        var settings = Substitute.For<StorageAccountSettings>();
-        var tableServiceClient = Substitute.For<TableServiceClient>();
         var eventDetails = new AdminEventDetails();
-        var repository = new AdminEventRepository(tableServiceClient, settings);
+        var repository = new AdminEventRepository(mockTableServiceClient, mockSettings);
 
         // Act
-        Func<Task> func = async () => await repository.CreateEvent(eventDetails);
+        await repository.CreateEvent(eventDetails);
 
         // Assert
-        func.Should().ThrowAsync<NotImplementedException>();
+        await mockTableClient.Received(1).AddEntityAsync(eventDetails, default);
     }
 
     [Fact]
-    public void Given_Instance_When_GetEvents_Invoked_Then_It_Should_Throw_Exception()
+    public async Task Given_Instance_When_GetEvents_Invoked_Then_It_Should_Invoke_QueryAsync_Method()
     {
         // Arrange
-        var settings = Substitute.For<StorageAccountSettings>();
-        var tableServiceClient = Substitute.For<TableServiceClient>();
-        var repository = new AdminEventRepository(tableServiceClient, settings);
+        var repository = new AdminEventRepository(mockTableServiceClient, mockSettings);
 
         // Act
-        Func<Task> func = async () => await repository.GetEvents();
+        await repository.GetEvents();
 
         // Assert
-        func.Should().ThrowAsync<NotImplementedException>();
+        mockTableClient.Received(1).QueryAsync<AdminEventDetails>();
     }
 
     [Theory]
@@ -94,16 +105,12 @@ public class AdminEventRepositoryTests
     public async Task Given_Failure_In_Get_Entity_When_GetEvent_Invoked_Then_It_Should_Throw_Exception(int statusCode)
     {
         // Arrange
-        var settings = Substitute.For<StorageAccountSettings>();
-        var tableServiceClient = Substitute.For<TableServiceClient>();
         var eventId = Guid.NewGuid();
-        var repository = new AdminEventRepository(tableServiceClient, settings);
+        var repository = new AdminEventRepository(mockTableServiceClient, mockSettings);
 
         var exception = new RequestFailedException(statusCode, "Request Error", default, default);
 
-        var tableClient = Substitute.For<TableClient>();
-        tableServiceClient.GetTableClient(Arg.Any<string>()).Returns(tableClient);
-        tableClient.GetEntityAsync<AdminEventDetails>(Arg.Any<string>(), Arg.Any<string>())
+        mockTableClient.GetEntityAsync<AdminEventDetails>(Arg.Any<string>(), Arg.Any<string>())
             .ThrowsAsync(exception);
 
         // Act
@@ -119,9 +126,7 @@ public class AdminEventRepositoryTests
     public async Task Given_Exist_EventId_When_GetEvent_Invoked_Then_It_Should_Return_AdminEventDetails(string eventId, string partitionKey)
     {
         // Arrange
-        var settings = Substitute.For<StorageAccountSettings>();
-        var tableServiceClient = Substitute.For<TableServiceClient>();
-        var repository = new AdminEventRepository(tableServiceClient, settings);
+        var repository = new AdminEventRepository(mockTableServiceClient, mockSettings);
 
         var eventDetails = new AdminEventDetails
         {
@@ -131,9 +136,7 @@ public class AdminEventRepositoryTests
 
         var response = Response.FromValue(eventDetails, Substitute.For<Response>());
 
-        var tableClient = Substitute.For<TableClient>();
-        tableServiceClient.GetTableClient(Arg.Any<string>()).Returns(tableClient);
-        tableClient.GetEntityAsync<AdminEventDetails>(partitionKey, eventId)
+        mockTableClient.GetEntityAsync<AdminEventDetails>(partitionKey, eventId)
             .Returns(Task.FromResult(response));
 
         // Act
@@ -144,19 +147,20 @@ public class AdminEventRepositoryTests
     }
 
     [Fact]
-    public void Given_Instance_When_UpdateEvent_Invoked_Then_It_Should_Throw_Exception()
+    public async Task Given_Instance_When_UpdateEvent_Invoked_Then_It_Should_Invoke_UpdateEntityAsync_Method()
     {
         // Arrange
-        var settings = Substitute.For<StorageAccountSettings>();
-        var tableServiceClient = Substitute.For<TableServiceClient>();
         var eventId = Guid.NewGuid();
         var eventDetails = new AdminEventDetails();
-        var repository = new AdminEventRepository(tableServiceClient, settings);
+        var repository = new AdminEventRepository(mockTableServiceClient, mockSettings);
 
         // Act
-        Func<Task> func = async () => await repository.UpdateEvent(eventId, eventDetails);
+        await repository.UpdateEvent(eventId, eventDetails);
 
         // Assert
-        func.Should().ThrowAsync<NotImplementedException>();
+        await mockTableClient.Received(1)
+                    .UpdateEntityAsync<AdminEventDetails>(Arg.Any<AdminEventDetails>(),
+                                                          Arg.Any<Azure.ETag>(),
+                                                          TableUpdateMode.Replace);
     }
 }

--- a/test/AzureOpenAIProxy.ApiApp.Tests/Repositories/AdminEventRepositoryTests.cs
+++ b/test/AzureOpenAIProxy.ApiApp.Tests/Repositories/AdminEventRepositoryTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Configuration;
-
-using Azure;
+﻿using Azure;
 using Azure.Data.Tables;
 
 using AzureOpenAIProxy.ApiApp.Configurations;
@@ -14,15 +12,13 @@ using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 
-using Xunit.Sdk;
-
 namespace AzureOpenAIProxy.ApiApp.Tests.Repositories;
 
 public class AdminEventRepositoryTests
 {
-    private StorageAccountSettings mockSettings;
-    private TableServiceClient mockTableServiceClient;
-    private TableClient mockTableClient;
+    private readonly StorageAccountSettings mockSettings;
+    private readonly TableServiceClient mockTableServiceClient;
+    private readonly TableClient mockTableClient;
 
     public AdminEventRepositoryTests()
     {
@@ -162,5 +158,24 @@ public class AdminEventRepositoryTests
                     .UpdateEntityAsync<AdminEventDetails>(Arg.Any<AdminEventDetails>(),
                                                           Arg.Any<Azure.ETag>(),
                                                           TableUpdateMode.Replace);
+    }
+
+    [Fact]
+    public async Task Given_Instance_When_DeleteEvent_Invoked_Then_It_Should_Invoke_DeleteEntityAsync_Method()
+    {
+        // Arrange
+        var eventDetails = new AdminEventDetails();
+        var repository = new AdminEventRepository(mockTableServiceClient, mockSettings);
+        var eventId = Guid.NewGuid();
+
+        eventDetails.EventId = eventId;
+
+        // Act
+        Guid deletedEventId = await repository.DeleteEvent(eventDetails);
+
+        // Assert
+        deletedEventId.Should().Be(eventId);
+        await mockTableClient.Received(1)
+                             .DeleteEntityAsync(Arg.Any<string>(), Arg.Any<string>());
     }
 }


### PR DESCRIPTION
### 작업중인 이슈
https://github.com/aliencube/azure-openai-sdk-proxy/issues/218

### 작업 내용
1. AdminEventRepository 클래스의 CreateEvent(), GetEvents(), UpdateEvent(), DeleteEvent() 기능 구현
2. AdminEventRepositoryTests 클래스에서 구현 안되었던 테스트 코드 구현
3. AdminEventService 클래스의 UpdateEvent(), DeleteEvent() 기능 구현
4. AdminEventServiceTests 클래스에서 구현 안되었던 테스트 코드 구현


### 궁금한 점
AdminEventRepository 클래스의 UpdateEvent() 함수가 EventId 파라미터를 전달 받도록 기존 인터페이스가 작성되어 있었는데,
이 EventId를 꼭 전달해주어야 하는지 궁금합니다. 
EventId와 함께 전달되는 AdminEventDetails 객체에 이미 EventId 필드가 있기 때문에 중복되는 것 같기도 해서요.
